### PR TITLE
Issue with puppet source keys and gitolite preseed.

### DIFF
--- a/templates/gitolite.preseed.erb
+++ b/templates/gitolite.preseed.erb
@@ -1,3 +1,3 @@
 gitolite gitolite/gituser string <%= git_user %>
-gitolite gitolite/adminkey string <%= git_admin_pubkey %>
+gitolite gitolite/adminkey string <%= "#{git_home}/#{git_user}.pub" %>
 gitolite gitolite/gitdir string <%= git_home %>


### PR DESCRIPTION
When puppet:///host/key.pub source type of a key is used, the preseed file is written with the URI instead of the file location. This commit changes so that in either case, source or content, the #{git_home}/#{git_user}.pub location is used to match gitolite.pp filename.
