### PR TITLE
Removed non-ascii characters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@
 #
 # === Copyright
 #
-# See LICENSE file, Sebastien Badia © 2012
+# See LICENSE file, Sebastien Badia (c) 2012
 # Tue Jul 03 20:06:33 +0200 2012
 
 # Class:: gitlab

--- a/manifests/pre.pp
+++ b/manifests/pre.pp
@@ -80,7 +80,7 @@ class gitlab::debian_packages {
   }
 
   case $::lsbdistcodename {
-    # Need to install a fresh ruby version…
+    # Need to install a fresh ruby version...
     'squeeze','precise': {
       package {
         ['checkinstall','libcurl4-openssl-dev','libreadline6-dev','libpq-dev',


### PR DESCRIPTION
Puppet refuses to load a manifest with non-ascii characters.  This includes the ellipsis '...' and copyright '(c)' as single characters.  I used the following grep to find them and replaced as appropriate:

grep --color='auto' -P -n "[\x80-\xFF]" init.pp
