### PR TITLE
Install correct Ruby package on Ubuntu 12.04

### DIFF
--- a/manifests/pre.pp
+++ b/manifests/pre.pp
@@ -154,6 +154,21 @@ class gitlab::debian_packages {
           refreshonly => true;
       }
     } # Squeeze, Precise
+    precise: {
+      package { 'ruby1.9.3': ensure => installed; }
+      exec { 'ruby-version':
+        command     => '/usr/bin/update-alternatives --set ruby /usr/bin/ruby1.9.1',
+        user        => root,
+        logoutput   => 'on_failure',
+        require     => Package['ruby1.9.3']
+      }
+      exec { 'gem-version':
+        command     => '/usr/bin/update-alternatives --set gem /usr/bin/gem1.9.1',
+        user        => root,
+        logoutput   => 'on_failure',
+        require     => Package['ruby1.9.3']
+      }
+    }
     default: {
       # Assuming default ruby 1.9.3 (wheezy,quantal,precise)
       package {


### PR DESCRIPTION
The default Ruby package in Ubuntu 12.04 (codename precise) installs Ruby 1.8.7 which will not run GitLab.  By providing a case for the precise codename that installs the "ruby1.9.3" package, this module can also be used on the latest LTS version of Ubuntu. Fixes issue #39 
