### PR TITLE
Fix GitLab home page address

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tested successfully with Gitlab 5.2-stable on Debian Wheezy with Puppet 3
 
-[GitLab](http://gitlabhq.org/) is a free project and repository management application
+[GitLab](http://gitlab.org/) is a free project and repository management application
 
 A [Puppet Module](http://docs.puppetlabs.com/learning/modules1.html#modules) is a collection of related content that can be used to model the configuration of a discrete service.
 


### PR DESCRIPTION
www.gitlabhq.org has expired. All other links still appear to be correct.
