### PR TITLE
Verify that $git_user's home directory is owned by $git_user

### DIFF
--- a/manifests/pre.pp
+++ b/manifests/pre.pp
@@ -21,6 +21,15 @@ class gitlab::pre {
       system     => true;
   }
 
+  file {
+    $git_home:
+      ensure  => present,
+      owner   => $git_user,
+      group   => $git_user,
+      require => User[$git_user],
+      recurse => true,
+  }
+
   # try and decide about the family here,
   # deal with version/dist specifics within the class
   case $::osfamily {


### PR DESCRIPTION
Puppet's user resource does not appear to ensure file ownership.  This causes issues if a pre-existing file system is mounted at the location that $git_user's home directory will be created.  Verifying that this resource is owned / grouped by $git_user resolves these issues.
