### PR TITLE
Update gitconfig user

### DIFF
--- a/templates/git.gitconfig.erb
+++ b/templates/git.gitconfig.erb
@@ -2,7 +2,7 @@
 # Module:: gitlab
 #
 [user]
-  name = <%= @git_user %>
+  name = "GitLab"
   email = <%= @git_email %>
 
 [core]


### PR DESCRIPTION
GitLab's check task is overly aggressive and requires that the username in .gitconfig matches "GitLab": https://github.com/gitlabhq/gitlabhq/blob/master/lib/tasks/gitlab/check.rake#L295

This change has no true impact but will allow a puppet-gitlab install to pass the check rake task.
