### PR TITLE
Add ability to manage username changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ _Note:_ Assume that a database server is already installed on your server/infras
 * gitlab\_ssl\_key: SSL Key location (default: /etc/ssl/private/ssl-cert-snakeoil.key)
 * gitlab\_ssl\_self_signed: Set true if your SSL Cert is self signed (default: false)
 * gitlab\_projects: GitLab default number of projects for new users (default: 10)
+* gitlab\_username\_change: Manage username changing in GitLab (default: true)
 * ldap\_enabled: Enable LDAP backend for gitlab web (see bellow) (default: false)
 * ldap\_host: FQDN of LDAP server (default: ldap.domain.com)
 * ldap\_base: LDAP base dn (default: dc=domain,dc=com)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@
 # [gitlab_ssl_self_signed] Set true if your SSL Cert is self signed (default: false)
 # [gitlab_projects] GitLab default number of projects for new users (default: 10)
 # [gitlab_repodir] Gitlab repository directory (default $git_home)
+# [gitlab_username_change] Gitlab username changing (default: true)
 # [ldap_enabled] Enable LDAP backend for gitlab web (see bellow) (default: false)
 # [ldap_host] FQDN of LDAP server (default: ldap.domain.com)
 # [ldap_base] LDAP base dn (default: dc=domain,dc=com)
@@ -81,6 +82,7 @@ class gitlab(
     $gitlab_ssl_key         = $gitlab::params::gitlab_ssl_key,
     $gitlab_ssl_self_signed = $gitlab::params::gitlab_ssl_self_signed,
     $gitlab_projects        = $gitlab::params::gitlab_projects,
+    $gitlab_username_change = $gitlab::params::gitlab_username_change,
     $ldap_enabled           = $gitlab::params::ldap_enabled,
     $ldap_host              = $gitlab::params::ldap_host,
     $ldap_base              = $gitlab::params::ldap_base,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class gitlab::params {
   $gitlab_ssl_key         = '/etc/ssl/private/ssl-cert-snakeoil.key'
   $gitlab_ssl_self_signed = false
   $gitlab_projects        = '10'
+  $gitlab_username_change = true
   $ldap_enabled           = false
   $ldap_host              = 'ldap.domain.com'
   $ldap_base              = 'dc=domain,dc=com'

--- a/templates/gitlab.yml.erb
+++ b/templates/gitlab.yml.erb
@@ -39,7 +39,7 @@ production: &base
     default_projects_limit: <%= @gitlab_projects %>
     # default_can_create_group: false  # default: true
     # default_can_create_team: false   # default: true
-    # username_changing_enabled: false # default: true - User can change her username/namespace
+    username_changing_enabled: <%= @gitlab_username_change ? 'true' : 'false' %> # default: true - User can change her username/namespace
 
     ## Users management
     # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.


### PR DESCRIPTION
Manage the "username_changing_enabled" setting in the gitlab.yml file.
