### PR TITLE
Don't start gitlab service until pids/ has been created

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -195,7 +195,8 @@ class gitlab::server {
   service {
     'gitlab':
       ensure     => running,
-      require    => File['/etc/init.d/gitlab'],
+      require    => [File['/etc/init.d/gitlab'],
+                     File["${git_home}/gitlab/tmp/pids"]],
       pattern    => 'puma',
       hasrestart => true,
       enable     => true;


### PR DESCRIPTION
Sometimes the gitlab service will not start on the first provision. It works on the second attempt though.

Puma writes to /home/git/gitlab/tmp/pids/puma.pid. If pids/ doesn't exist, it fails silently. The order in which server.pp is run seems to cause the differing behaviour on fresh VMs.
