### PR TITLE
Trigger nginx to restart after config added

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -208,7 +208,8 @@ class gitlab::server {
       content => template('gitlab/nginx-gitlab.conf.erb'),
       owner   => root,
       group   => root,
-      mode    => '0644';
+      mode    => '0644',
+      notify  => Service["nginx"];
   }
 
 } # Class:: gitlab::server


### PR DESCRIPTION
Related to #54 and #58.

Gitlab does not start up on the first provision because nginx does not actually watch /etc/nginx/conf.d/. By default it watches /tmp/nginx.d/.

I thought about putting the file in /tmp/nginx.d/, but that location is configurable, so this commit instead just notifies the service directly.
