### PR TITLE
Added path to ruby executables on an rvm-only system

### DIFF
--- a/manifests/gitlabshell.pp
+++ b/manifests/gitlabshell.pp
@@ -33,7 +33,7 @@ class gitlab::gitlabshell {
       unless    => "/usr/bin/test -d ${git_home}/gitlab-shell";
     'Setup gitlab-shell':
       command   => "ruby ${git_home}/gitlab-shell/bin/install",
-      path      => '/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      path      => '/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/rvm/wrappers/default/',
       user      => $git_user,
       cwd       => $git_home,
       require   => File["${git_home}/gitlab-shell/config.yml"],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,7 +45,7 @@ class gitlab::server {
   }
 
   Exec{
-    path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/rvm/bin',
     logoutput   => 'on_failure',
   }
 


### PR DESCRIPTION
I am using rvm to manage my ruby versions since I can't get the version I need through my distro package manager.  Needed to add this path for things to run.
