### PR TITLE
Disable shell for git user

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -10,7 +10,7 @@ class gitlab::setup inherits gitlab {
   # user
   user { $gitlab::params::git_user:
     ensure   => present,
-    shell    => '/bin/bash',
+    shell    => '/bin/false',
     password => '*',
     home     => $gitlab::params::git_home,
     comment  => $gitlab::params::git_comment,


### PR DESCRIPTION
The documentation for gitlab instructs you to add the user with --disabled-login. 

disabling login sets the users shell to /bin/false by default. 

This has not yet been tested.
