### PR TITLE
Create .git_setup_done file

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -59,6 +59,7 @@ class gitlab::install inherits gitlab {
     command => "bundle install --without development aws test ${gitlab_without_gems} --deployment",
     cwd     => "${git_home}/gitlab",
     unless  => "/usr/bin/test -f ${git_home}/.git_setup_done",
+    creates => "${git_home}/.git_setup_done",
     timeout => 0,
     require => [
       File["${git_home}/gitlab/config/database.yml"],


### PR DESCRIPTION
The [install gitlab](https://github.com/sbadia/puppet-gitlab/blob/master/manifests/install.pp#L58) command will currently be processed every Puppet run.  In 53c1c24c when I initially refactored the module, I created the file .gitlab_setup_done, but was testing for the file .git_setup_done.  In cc27170c, @sbadia updated [setup gitlab database](https://github.com/sbadia/puppet-gitlab/blob/master/manifests/install.pp#L71) to fix the issue I had created, but overlooked [install gitlab](https://github.com/sbadia/puppet-gitlab/blob/master/manifests/install.pp#L58).  In e803258b, @sbadia added a file resource for .git_setup_done, but never created the file.  This commit addresses the creation of that file and should resolve the issue.

I am without my laptop so I will be unable to test this fix until this afternoon.
