### PR TITLE
added ruby-dev, make and build-essentials to default packages

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -89,5 +89,5 @@ class gitlab::setup inherits gitlab {
   }
 
   # other packages
-  ensure_packages(['git-core','postfix','curl'])
+  ensure_packages(['git-core','postfix','curl','ruby-dev','make','build-essential'])
 }


### PR DESCRIPTION
The instalation failed because charlock_holmes couldn't be installed. I've looked into the logs and the problem was that it needs ruby-dev, make and build-essential installed to be able to compile. 

I've modified the setup.pp adding this packages to the default packages
