### PR TITLE
some people have strange PATHs, let's respect that

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See [gitlab example](https://github.com/sbadia/vagrant-gitlab/blob/master/exampl
 * `gitlab_projects`: GitLab default number of projects for new users (default: 10)
 * `gitlab_username_change`: Manage username changing in GitLab (default: true)
 * `gitlab_unicorn_port`: Port that unicorn listens on 172.0.0.1 for HTTP traffic (default: 8080)
+* `exec_path`: PATH of executtion (default: `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`)
 * `ldap_enabled`: Enable LDAP backend for gitlab web (see bellow) (default: false)
 * `ldap_host`: FQDN of LDAP server (default: ldap.domain.com)
 * `ldap_base`: LDAP base dn (default: dc=domain,dc=com)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,6 +205,7 @@ class gitlab(
     $gitlab_projects        = $gitlab::params::gitlab_projects,
     $gitlab_username_change = $gitlab::params::gitlab_username_change,
     $gitlab_unicorn_port    = $gitlab::params::gitlab_unicorn_port,
+    $exec_path              = $gitlab::params::exec_path,
     $ldap_enabled           = $gitlab::params::ldap_enabled,
     $ldap_host              = $gitlab::params::ldap_host,
     $ldap_base              = $gitlab::params::ldap_base,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class gitlab::install inherits gitlab {
 
   Exec {
     user => $git_user,
-    path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    path => $exec_path,
   }
 
   File {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class gitlab::params {
   $gitlab_projects        = '10'
   $gitlab_username_change = true
   $gitlab_unicorn_port    = '8080'
+  $exec_path              = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   $ldap_enabled           = false
   $ldap_host              = 'ldap.domain.com'
   $ldap_base              = 'dc=domain,dc=com'

--- a/spec/classes/gitlab_spec.rb
+++ b/spec/classes/gitlab_spec.rb
@@ -31,6 +31,7 @@ describe 'gitlab' do
       :gitlab_projects        => '42',
       :gitlab_username_change => false,
       :gitlab_unicorn_port    => '8888',
+      :exec_path              => '/opt/bw/bin:/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin',
       :ldap_host              => 'ldap.fooboozoo.fr',
       :ldap_base              => 'dc=fooboozoo,dc=fr',
       :ldap_port              => '666',
@@ -383,7 +384,7 @@ describe 'gitlab' do
         it { should contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/port: #{params_set[:gitlab_redisport]}/)}
         it { should contain_exec('install gitlab-shell').with(
           :user     => params_set[:git_user],
-          :path     => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :path     => params_set[:exec_path],
           :command  => "ruby #{params_set[:git_home]}/gitlab-shell/bin/install",
           :cwd      => params_set[:git_home],
           :creates  => "#{params_set[:gitlab_repodir]}/repositories",
@@ -472,7 +473,7 @@ describe 'gitlab' do
       describe 'install gitlab' do
         it { should contain_exec('install gitlab').with(
           :user    => params_set[:git_user],
-          :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :path    => params_set[:exec_path],
           :command => 'bundle install --without development aws test postgres --deployment',
           :cwd     => "#{params_set[:git_home]}/gitlab",
           :creates => "#{params_set[:git_home]}/.git_setup_done",
@@ -492,7 +493,7 @@ describe 'gitlab' do
           let(:params) { params_set.merge({ :gitlab_dbtype => 'pgsql' }) }
           it { should contain_exec('install gitlab').with(
             :user    => params_set[:git_user],
-            :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :path    => params_set[:exec_path],
             :command => 'bundle install --without development aws test mysql --deployment',
             :cwd     => "#{params_set[:git_home]}/gitlab",
             :creates => "#{params_set[:git_home]}/.git_setup_done",
@@ -507,7 +508,7 @@ describe 'gitlab' do
       describe 'setup gitlab database' do
         it { should contain_exec('setup gitlab database').with(
           :user    => params_set[:git_user],
-          :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :path    => params_set[:exec_path],
           :command => '/usr/bin/yes yes | bundle exec rake gitlab:setup RAILS_ENV=production',
           :cwd     => "#{params_set[:git_home]}/gitlab",
           :creates => "#{params_set[:git_home]}/.gitlab_setup_done",


### PR DESCRIPTION
Some platforms, or companies.. put their ruby installations in strange
location. We should respect that, by making the Exec path configurable.

Documentation + tests included!
