### PR TITLE
explicitly install rake that GitLab depends on

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -91,6 +91,10 @@ class gitlab::setup inherits gitlab {
     ensure    => '10.1.0',
     provider  => gem,
   }
+  package { 'i18n':
+    ensure    => '0.6.9',
+    provider  => gem,
+  }
 
   # other packages
   ensure_packages(['git-core','postfix','curl'])

--- a/spec/classes/gitlab_spec.rb
+++ b/spec/classes/gitlab_spec.rb
@@ -184,6 +184,10 @@ describe 'gitlab' do
           :ensure   => '10.1.0',
           :provider => 'gem'
         )}
+        it { should contain_package('i18n').with(
+          :ensure   => '0.6.9',
+          :provider => 'gem'
+        )}
       end
       #### Commons packages (all dist.)
       describe 'commons packages' do


### PR DESCRIPTION
GitLab's setup task depends on rake-10.1.0, make sure it's installed
This fixes #91
