### PR TITLE
Harden SSL Configuration

### DIFF
--- a/templates/nginx-gitlab.conf.erb
+++ b/templates/nginx-gitlab.conf.erb
@@ -26,8 +26,8 @@ server {
   ssl                           on;
   ssl_certificate               <%= @gitlab_ssl_cert %>;
   ssl_certificate_key           <%= @gitlab_ssl_key %>;
-  ssl_protocols                 SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers                   AES:HIGH:!aNULL:!MD5:!ADH:!MDF;
+  ssl_protocols                 TLSv1.2 TLSv1.1 TLSv1;
+  ssl_ciphers                   AES:HIGH:!aNULL:!RC4:!MD5:!ADH:!MDF;
   ssl_prefer_server_ciphers     on;
 <% end %>
 


### PR DESCRIPTION
As noted in issue #103, our SSL configuration is currently insecure.  Specifically, aNULL ciphers must be excluded in our configuration.  Along with ssl_prefer_server_ciphers (which we have already set), this should protect us from exploits similar to the BEAST attack.  Including SSLv3 seems to be fine according to resources I have skimmed.

That said, I am not fluent with SSL certificates and would like input from @igalic and others on the topic.  

References:
- http://nginx.org/en/docs/http/configuring_https_servers.html
- http://www.hybridforge.com/blog/nginx-ssl-ciphers-and-pci-compliance
