### PR TITLE
add packages needed for building charlock_holmes and to run the init scr...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,8 @@ class gitlab::params {
     'Debian': {
       # system packages
       $system_packages = ['libicu-dev', 'python2.7','python-docutils',
-                          'libxml2-dev', 'libxslt1-dev','python-dev']
+                          'libxml2-dev', 'libxslt1-dev','python-dev',
+                          'build-essential','ruby-dev','sudo']
     }
     'RedHat': {
       # system packages


### PR DESCRIPTION
On a brand new netinst install, build-essential and ruby-dev are required to build charlock_holmes. Also, sudo is necessary for the init.d script