### PR TITLE
Fix incorrect version of puppet being installed in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-if ENV.key?('PUPPET_VERSION')
-  puppetversion = "= #{ENV['PUPPET_VERSION']}"
+if ENV.key?('PUPPET_GEM_VERSION')
+  puppetversion = ENV['PUPPET_GEM_VERSION']
 else
   puppetversion = ['>= 3.0']
 end


### PR DESCRIPTION
I noticed the latest version of puppet was always being used in the travis builds due to mismatching environment variables in the Gemfile and .travis.yml. I've updated the Gemfile to use the PUPPET_GEM_VERSION env so that it matches .travis.yml.
