### PR TITLE
Allow specifying of a non-standard ssh port for gitlab

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -184,6 +184,10 @@
 #   Package name for git install
 #   default: git-core (Debian)
 #
+# [*ssh_port*]
+#   Port accepting ssh connections
+#   default: 22
+#
 # === Examples
 #
 # See examples/gitlab.pp
@@ -255,6 +259,7 @@ class gitlab(
     $ldap_bind_dn             = $gitlab::params::ldap_bind_dn,
     $ldap_bind_password       = $gitlab::params::ldap_bind_password,
     $git_package_name         = $gitlab::params::git_package_name,
+    $ssh_port                 = $gitlab::params::ssh_port,
   ) inherits gitlab::params {
   case $::osfamily {
     Debian: {}
@@ -287,6 +292,7 @@ class gitlab(
   validate_re($gitlab_unicorn_port, '^\d+$', 'gitlab_unicorn_port is not valid')
   validate_re($gitlab_unicorn_worker, '^\d+$', 'gitlab_unicorn_worker is not valid')
   validate_re($ensure, '(present|latest)', 'ensure is not valid (present|latest)')
+  validate_re($ssh_port, '^\d+$', 'ssh_port is not a valid port')
 
   validate_string($git_user)
   validate_string($git_email)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,6 +48,7 @@ class gitlab::params {
   $ldap_method              = 'ssl'
   $ldap_bind_dn             = ''
   $ldap_bind_password       = ''
+  $ssh_port                 = '22'
 
 
   # determine pre-requisite packages

--- a/spec/classes/gitlab_config_spec.rb
+++ b/spec/classes/gitlab_config_spec.rb
@@ -40,7 +40,8 @@ describe 'gitlab' do
       :ldap_uid               => 'cn',
       :ldap_method            => 'tls',
       :ldap_bind_dn           => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
-      :ldap_bind_password     => 'aV!oo1ier5ahch;a'
+      :ldap_bind_password     => 'aV!oo1ier5ahch;a',
+      :ssh_port               => '2223'
     }
   end
 

--- a/spec/classes/gitlab_init_spec.rb
+++ b/spec/classes/gitlab_init_spec.rb
@@ -40,7 +40,8 @@ describe 'gitlab' do
       :ldap_uid               => 'cn',
       :ldap_method            => 'tls',
       :ldap_bind_dn           => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
-      :ldap_bind_password     => 'aV!oo1ier5ahch;a'
+      :ldap_bind_password     => 'aV!oo1ier5ahch;a',
+      :ssh_port               => '2223'
     }
   end
 

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -41,7 +41,8 @@ describe 'gitlab' do
       :ldap_uid                 => 'cn',
       :ldap_method              => 'tls',
       :ldap_bind_dn             => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
-      :ldap_bind_password       => 'aV!oo1ier5ahch;a'
+      :ldap_bind_password       => 'aV!oo1ier5ahch;a',
+      :ssh_port                 => '2223'
     }
   end
 
@@ -136,6 +137,7 @@ describe 'gitlab' do
         it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/path: \/home\/git\/gitlab-satellites\//)}
         it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/repos_path: \/home\/git\/repositories\//)}
         it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/hooks_path: \/home\/git\/gitlab-shell\/hooks\//)}
+        it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/ssh_port: 22/)}
       end # gitlab config
       describe 'resque config' do
         it { should contain_file('/home/git/gitlab/config/resque.yml').with(:ensure => 'file',:owner => 'git',:group => 'git')}
@@ -292,6 +294,7 @@ describe 'gitlab' do
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/path: #{params_set[:git_home]}\/gitlab-satellites\//)}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/repos_path: #{params_set[:gitlab_repodir]}\/repositories\//)}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/hooks_path: #{params_set[:git_home]}\/gitlab-shell\/hooks\//)}
+        it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/ssh_port: #{params_set[:ssh_port]}/)}
       end # gitlab config
       describe 'resque config' do
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/resque.yml").with(:ensure => 'file',:owner => params_set[:git_user],:group => params_set[:git_user])}

--- a/spec/classes/gitlab_package_spec.rb
+++ b/spec/classes/gitlab_package_spec.rb
@@ -40,7 +40,8 @@ describe 'gitlab' do
       :ldap_uid               => 'cn',
       :ldap_method            => 'tls',
       :ldap_bind_dn           => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
-      :ldap_bind_password     => 'aV!oo1ier5ahch;a'
+      :ldap_bind_password     => 'aV!oo1ier5ahch;a',
+      :ssh_port               => '2223'
     }
   end
 

--- a/spec/classes/gitlab_service_spec.rb
+++ b/spec/classes/gitlab_service_spec.rb
@@ -40,7 +40,8 @@ describe 'gitlab' do
       :ldap_uid               => 'cn',
       :ldap_method            => 'tls',
       :ldap_bind_dn           => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
-      :ldap_bind_password     => 'aV!oo1ier5ahch;a'
+      :ldap_bind_password     => 'aV!oo1ier5ahch;a',
+      :ssh_port               => '2223'
     }
   end
 

--- a/spec/classes/gitlab_setup_spec.rb
+++ b/spec/classes/gitlab_setup_spec.rb
@@ -40,7 +40,8 @@ describe 'gitlab' do
       :ldap_uid               => 'cn',
       :ldap_method            => 'tls',
       :ldap_bind_dn           => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
-      :ldap_bind_password     => 'aV!oo1ier5ahch;a'
+      :ldap_bind_password     => 'aV!oo1ier5ahch;a',
+      :ssh_port               => '2223'
     }
   end
 

--- a/templates/gitlab.yml.erb
+++ b/templates/gitlab.yml.erb
@@ -203,7 +203,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @ssh_port %>
 
   ## Git settings
   # CAUTION!


### PR DESCRIPTION
This PR adds an extra parameter, allowing you to specify the ssh port the gitlab interface expects, defaulting to 22.

In my case, I needed to set this to 2222 because I have sshd listening on port 22 in a LXC container, but I access it through a forwarded port (2222)..
