### PR TITLE
Run migrations if gitlab is upgraded by `gitlab install`

### DIFF
--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -158,7 +158,14 @@ describe 'gitlab' do
           :require => ['File[/home/git/gitlab/config/database.yml]',
                         'File[/home/git/gitlab/config/unicorn.rb]',
                         'File[/home/git/gitlab/config/gitlab.yml]',
-                        'File[/home/git/gitlab/config/resque.yml]']
+                        'File[/home/git/gitlab/config/resque.yml]'],
+          :notify  => 'Exec[run migrations]'
+        )}
+        it { should contain_exec('run migrations').with(
+          :command     => 'bundle exec rake db:migrate RAILS_ENV=production',
+          :cwd         => '/home/git/gitlab',
+          :refreshonly => 'true',
+          :notify      => 'Exec[precompile assets]'
         )}
         context 'postgresql' do
           let(:params) {{ :gitlab_dbtype => 'pgsql' }}
@@ -183,7 +190,14 @@ describe 'gitlab' do
           :command => '/usr/bin/yes yes | bundle exec rake gitlab:setup RAILS_ENV=production',
           :cwd     => '/home/git/gitlab',
           :creates => '/home/git/.gitlab_setup_done',
-          :require => 'Exec[install gitlab]'
+          :before  => 'Exec[run migrations]',
+          :require => 'Exec[install gitlab]',
+          :notify  => 'Exec[precompile assets]'
+        )}
+        it { should contain_exec('precompile assets').with(
+          :command     => 'bundle exec rake assets:clean assets:precompile cache:clear RAILS_ENV=production',
+          :cwd         => '/home/git/gitlab',
+          :refreshonly => 'true'
         )}
         it { should contain_file("/home/git/.gitlab_setup_done").with(
           :ensure   => 'present',


### PR DESCRIPTION
At the moment only the `setup gitlab database` exec is run on
first run or until the `.gitlab_setup_done` file is deleted. But
upgrading gitlab normally requires running the db migrations.

This PR also adds some additional tasks to the `precompile assets`
exec that cleans the assets before precompiling as well as cleaning
the cache.
