### PR TITLE
Test with a different ssh port

### DIFF
--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -42,7 +42,7 @@ describe 'gitlab' do
       :ldap_method              => 'tls',
       :ldap_bind_dn             => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
       :ldap_bind_password       => 'aV!oo1ier5ahch;a',
-      :ssh_port                 => '2223'
+      :ssh_port                 => '6666'
     }
   end
 


### PR DESCRIPTION
Can the following test pass in undesired circumstances because it matches our custom port as well?

```
it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/ssh_port: 22/)}
```
