### PR TITLE
Add param to set bundler flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ See [gitlab example](https://github.com/sbadia/vagrant-gitlab/blob/master/exampl
 * `gitlab_username_change`: Manage username changing in GitLab (default: true)
 * `gitlab_unicorn_port`: Port that unicorn listens on 172.0.0.1 for HTTP traffic (default: 8080)
 * `gitlab_unicorn_worker`: Number of unicorn workers (default: 2)
+* `gitlab_bundler_flags`: Flags to be passed to bundler when installing gems (default: --deployment)
 * `exec_path`: PATH of executtion (default: `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`)
 * `ldap_enabled`: Enable LDAP backend for gitlab web (see bellow) (default: false)
 * `ldap_host`: FQDN of LDAP server (default: ldap.domain.com)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,10 @@
 #   Port that unicorn listens on 172.0.0.1 for HTTP traffic
 #   (default: 8080)
 #
+# [*gitlab_bundler_flags*]
+#   Flags that should be passed to bundler when installing gems
+#   (default: --deployment)
+#
 # [*ldap_enabled*]
 #   Enable LDAP backend for gitlab web (see bellow)
 #   default: false
@@ -249,6 +253,7 @@ class gitlab(
     $gitlab_username_change   = $gitlab::params::gitlab_username_change,
     $gitlab_unicorn_port      = $gitlab::params::gitlab_unicorn_port,
     $gitlab_unicorn_worker    = $gitlab::params::gitlab_unicorn_worker,
+    $gitlab_bundler_flags     = $gitlab::params::gitlab_bundler_flags,
     $exec_path                = $gitlab::params::exec_path,
     $ldap_enabled             = $gitlab::params::ldap_enabled,
     $ldap_host                = $gitlab::params::ldap_host,
@@ -305,6 +310,7 @@ class gitlab(
   validate_string($gitlab_dbuser)
   validate_string($gitlab_dbpwd)
   validate_string($gitlab_dbhost)
+  validate_string($gitlab_bundler_flags)
   validate_string($ldap_base)
   validate_string($ldap_uid)
   validate_string($ldap_host)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -69,7 +69,7 @@ class gitlab::install inherits gitlab {
   }
 
   exec { 'install gitlab':
-    command => "bundle install --without development aws test ${gitlab_without_gems} --deployment",
+    command => "bundle install --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
     cwd     => "${git_home}/gitlab",
     unless  => 'bundle check',
     timeout => 0,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class gitlab::params {
   $gitlab_username_change   = true
   $gitlab_unicorn_port      = '8080'
   $gitlab_unicorn_worker    = '2'
+  $gitlab_bundler_flags     = '--deployment'
   $exec_path                = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   $ldap_enabled             = false
   $ldap_host                = 'ldap.domain.com'

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -34,6 +34,7 @@ describe 'gitlab' do
       :gitlab_username_change   => false,
       :gitlab_unicorn_port      => '8888',
       :gitlab_unicorn_worker    => '8',
+      :gitlab_bundler_flags     => '--no-deployment',
       :exec_path                => '/opt/bw/bin:/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin',
       :ldap_host                => 'ldap.fooboozoo.fr',
       :ldap_base                => 'dc=fooboozoo,dc=fr',
@@ -324,7 +325,7 @@ describe 'gitlab' do
         it { should contain_exec('install gitlab').with(
           :user    => params_set[:git_user],
           :path    => params_set[:exec_path],
-          :command => 'bundle install --without development aws test postgres --deployment',
+          :command => "bundle install --without development aws test postgres #{params_set[:gitlab_bundler_flags]}",
           :unless  => 'bundle check',
           :cwd     => "#{params_set[:git_home]}/gitlab",
           :timeout => 0,
@@ -338,7 +339,7 @@ describe 'gitlab' do
           it { should contain_exec('install gitlab').with(
             :user    => params_set[:git_user],
             :path    => params_set[:exec_path],
-            :command => 'bundle install --without development aws test mysql --deployment',
+            :command => "bundle install --without development aws test mysql #{params_set[:gitlab_bundler_flags]}",
             :unless  => 'bundle check',
             :cwd     => "#{params_set[:git_home]}/gitlab",
             :timeout => 0,


### PR DESCRIPTION
Using a custom omniauth provider often requires adding an additional gem.  To install gems with a modified gem file, the bundle command must be run with the `--no-deployment` flag.  See [Custom omniauth provider configurations](https://github.com/gitlabhq/gitlab-public-wiki/wiki/Custom-omniauth-provider-configurations) for the recommendation.

This is probably the first step in allowing configuration of omniauth.
