### PR TITLE
Add param for Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See [gitlab example](https://github.com/sbadia/vagrant-gitlab/blob/master/exampl
 * `ldap_bind_dn`: User for LDAP bind auth (default: nil)
 * `ldap_bind_password`: Password for LDN bind auth (default: nil)
 * `git_package_name`: Package name for git (default: git-core)
+* `google_analytics_id`: Google Analytics tracking ID (default: nil)
 
 # Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,6 +192,10 @@
 #   Port accepting ssh connections
 #   default: 22
 #
+# [*google_analytics_id*]
+#   Google analytics tracking ID
+#   default: nil
+#
 # === Examples
 #
 # See examples/gitlab.pp
@@ -265,6 +269,7 @@ class gitlab(
     $ldap_bind_password       = $gitlab::params::ldap_bind_password,
     $git_package_name         = $gitlab::params::git_package_name,
     $ssh_port                 = $gitlab::params::ssh_port,
+    $google_analytics_id      = $gitlab::params::google_analytics_id
   ) inherits gitlab::params {
   case $::osfamily {
     Debian: {}
@@ -314,6 +319,7 @@ class gitlab(
   validate_string($ldap_base)
   validate_string($ldap_uid)
   validate_string($ldap_host)
+  validate_string($google_analytics_id)
 
   anchor { 'gitlab::begin': } ->
   class { '::gitlab::setup': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,7 @@ class gitlab::params {
   $ldap_bind_dn             = ''
   $ldap_bind_password       = ''
   $ssh_port                 = '22'
+  $google_analytics_id      = ''
 
 
   # determine pre-requisite packages

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -38,7 +38,8 @@ describe 'gitlab' do
       :ldap_method              => 'tls',
       :ldap_bind_dn             => 'uid=gitlab,o=bots,dc=fooboozoo,dc=fr',
       :ldap_bind_password       => 'aV!oo1ier5ahch;a',
-      :ssh_port                 => '2223'
+      :ssh_port                 => '2223',
+      :google_analytics_id      => 'UA-12345678-9'
     }
   end
 
@@ -134,6 +135,7 @@ describe 'gitlab' do
         it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/^\s*repos_path: \/home\/git\/repositories\/$/)}
         it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/^\s*hooks_path: \/home\/git\/gitlab-shell\/hooks\/$/)}
         it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/^\s*ssh_port: 22$/)}
+        it { should contain_file('/home/git/gitlab/config/gitlab.yml').with_content(/^\s*# google_analytics_id: '_your_tracking_id'$/)}
       end # gitlab config
       describe 'resque config' do
         it { should contain_file('/home/git/gitlab/config/resque.yml').with(:ensure => 'file',:owner => 'git',:group => 'git')}
@@ -305,6 +307,7 @@ describe 'gitlab' do
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*repos_path: #{params_set[:gitlab_repodir]}\/repositories\/$/)}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*hooks_path: #{params_set[:git_home]}\/gitlab-shell\/hooks\/$/)}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*ssh_port: #{params_set[:ssh_port]}$/)}
+        it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*google_analytics_id: #{params_set[:google_analytics_id]}$/)}
       end # gitlab config
       describe 'resque config' do
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/resque.yml").with(:ensure => 'file',:owner => params_set[:git_user],:group => params_set[:git_user])}

--- a/templates/gitlab.yml.erb
+++ b/templates/gitlab.yml.erb
@@ -229,7 +229,12 @@ production: &base
 
   extra:
     ## Google analytics. Uncomment if you want it
+<% if @google_analytics_id != '' %>
+    google_analytics_id: <%= @google_analytics_id %>
+<% else %>
     # google_analytics_id: '_your_tracking_id'
+<% end %>
+
 
     ## Text under sign-in page (Markdown enabled)
     # sign_in_text: |


### PR DESCRIPTION
Just another config file management option.  Add your Google Analytics ID; GitLab will use it.
