### PR TITLE
Update required packages

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -89,7 +89,7 @@ class gitlab::setup inherits gitlab {
   }
 
   # other packages
-  ensure_packages([$git_package_name,'postfix','curl','ruby-dev','build-essential'])
+  ensure_packages([$git_package_name,'postfix','curl','ruby-dev','build-essential','nginx'])
   
   if $gitlab_redishost == '127.0.0.1' {
     ensure_packages(['redis-server'])


### PR DESCRIPTION
Add ruby-dev, redis-server, nginx & build-essential to required packages

Fix for:

```
Error: Could not update: Execution of '/usr/bin/gem install -v 0.6.9.4 --no-rdoc --no-ri charlock_holmes' returned 1: Building native extensions.  This could take a while...
ERROR:  Error installing charlock_holmes:
    ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from extconf.rb:1:in `<main>'
```
