### PR TITLE
Fix travis gate (pin rake to 10.1.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,9 @@ else
   puppetversion = ['>= 3.0']
 end
 
-gem 'rake'
-gem 'puppet-lint'
+gem 'rake', '10.1.0'
+gem 'puppet-lint', '~> 0.3.2'
 gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
 gem 'puppet-syntax'
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper'
-gem 'rspec-system'
-gem 'rspec-system-puppet'
-gem 'rspec-system-serverspec'


### PR DESCRIPTION
The latest Rake update requires Ruby >= 1.9. Bundler in the
current gate uses 1.8.x. This update fixes the gate by pinning
Rake to the last known working version.
