### PR TITLE
Charlock_holmes gem must require libicu-devel

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,14 +58,16 @@ class gitlab::params {
   case $::osfamily {
     'Debian': {
       $git_package_name = 'git-core'
+      $libicu_package_name = 'libicu-dev'
       # system packages
-      $system_packages = ['libicu-dev', 'python2.7','python-docutils',
+      $system_packages = [$libicu_package_name, 'python2.7','python-docutils',
                           'libxml2-dev', 'libxslt1-dev','python-dev']
     }
     'RedHat': {
       $git_package_name = 'git'
+      $libicu_package_name = 'libicu-devel'
       # system packages
-      $system_packages = ['libicu-devel', 'perl-Time-HiRes','libxml2-devel',
+      $system_packages = [$libicu_package_name, 'perl-Time-HiRes','libxml2-devel',
                           'libxslt-devel','python-devel','libcurl-devel',
                           'readline-devel','openssl-devel','zlib-devel',
                           'libyaml-devel','patch','gcc-c++']

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -86,6 +86,7 @@ class gitlab::setup inherits gitlab {
   package { 'charlock_holmes':
     ensure    => '0.6.9.4',
     provider  => gem,
+    require   => Package[$libicu_package_name]
   }
 
   # other packages

--- a/spec/classes/gitlab_setup_spec.rb
+++ b/spec/classes/gitlab_setup_spec.rb
@@ -80,7 +80,8 @@ describe 'gitlab' do
         },
         'system_packages' => ['libicu-dev', 'python2.7','python-docutils',
                               'libxml2-dev','libxslt1-dev','python-dev'],
-        'git_packages' => ['git-core']
+        'git_packages' => ['git-core'], 
+        'libicu_packages' => ['libicu-dev']
       },
       'RedHat' => {
         'db_packages' => {
@@ -91,7 +92,8 @@ describe 'gitlab' do
                               'libxslt-devel','python-devel','libcurl-devel',
                               'readline-devel','openssl-devel','zlib-devel',
                               'libyaml-devel','patch','gcc-c++'],
-        'git_packages' => ['git']
+        'git_packages' => ['git'],
+        'libicu_packages' => ['libicu-devel']
       }
     }
 
@@ -117,6 +119,9 @@ describe 'gitlab' do
           p[distro]['git_packages'].each do |pkg|
             it { should contain_package(pkg) }
           end
+          p[distro]['libicu_packages'].each do |pkg|
+            it { should contain_package(pkg) }
+          end
         end
       end
       #### Gems (all dist.)
@@ -127,7 +132,8 @@ describe 'gitlab' do
         )}
         it { should contain_package('charlock_holmes').with(
           :ensure   => '0.6.9.4',
-          :provider => 'gem'
+          :provider => 'gem',
+          :require  => 'Package[libicu-dev]'
         )}
       end
       #### Commons packages (all dist.)


### PR DESCRIPTION
The installation of charlock_holmes gem fails  on fresh installed systems
that does not have the libicu-devel.

This commit fix this problem making charlock_holmes gems require libicu-devel
package.

package installed the installation of charlock holmes
