### PR TITLE
Request nginx restart after creating the nginx config file.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,7 @@ class gitlab::config inherits gitlab {
     owner   => root,
     group   => root,
     mode    => '0644',
+    notify  => Service['nginx']
   }
 
   file { '/etc/default/gitlab':

--- a/spec/classes/gitlab_config_spec.rb
+++ b/spec/classes/gitlab_config_spec.rb
@@ -46,7 +46,8 @@ describe 'gitlab' do
           :ensure => 'file',
           :owner  => 'root',
           :group  => 'root',
-          :mode   => '0644'
+          :mode   => '0644',
+          :notify => 'Service[nginx]'
         )}
         it { should contain_file('/etc/nginx/conf.d/gitlab.conf').with_content(/^\s*server unix:\/home\/git\/gitlab\/tmp\/sockets\/gitlab.socket;$/)}
         it { should contain_file('/etc/nginx/conf.d/gitlab.conf').with_content(/^\s*listen 80;$/)}


### PR DESCRIPTION
We should notify nginx service after creating the nginx config file.
This is necessary for nginx to apply the new created config file.

Without this, we need to manually (reload/restart) the nginx service after running
gitlab puppet module. (not desirable behaviour.)

This commit fix this problem making nginx config file notify the nginx service.
because of this puppet will restart nginx, making possible to access the gitlab
url correctly after the gitlab puppet module execution.
