### PR TITLE
Allow adjustment of number of bundler threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See [gitlab example](https://github.com/sbadia/vagrant-gitlab/blob/master/exampl
 * `gitlab_unicorn_port`: Port that unicorn listens on 172.0.0.1 for HTTP traffic (default: 8080)
 * `gitlab_unicorn_worker`: Number of unicorn workers (default: 2)
 * `gitlab_bundler_flags`: Flags to be passed to bundler when installing gems (default: --deployment)
+* `gitlab_bundler_jobs`: The number of jobs to use while installing gems. Should match number of CPUs on machine (default: number of system processors)
 * `gitlab_ensure_postfix`: Whether or not this module should ensure the postfix
   package is installed (used to manage conflicts with other modules) (default:
 true)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,10 @@
 #   Flags that should be passed to bundler when installing gems
 #   (default: --deployment)
 #
+# [*gitlab_bundler_jobs*]
+#   Number of jobs to use while installing gems.  Should match number of
+#   procs on your system (default: number of processors on system)
+#
 # [*gitlab_ensure_postfix*]
 #   Whether or not this module should ensure the postfix package is
 #   installed (used to manage conflicts with other modules)
@@ -283,6 +287,7 @@ class gitlab(
     $gitlab_unicorn_port      = $gitlab::params::gitlab_unicorn_port,
     $gitlab_unicorn_worker    = $gitlab::params::gitlab_unicorn_worker,
     $gitlab_bundler_flags     = $gitlab::params::gitlab_bundler_flags,
+    $gitlab_bundler_jobs      = $gitlab::params::gitlab_bundler_jobs,
     $gitlab_ensure_postfix    = $gitlab::params::gitlab_ensure_postfix,
     $exec_path                = $gitlab::params::exec_path,
     $ldap_enabled             = $gitlab::params::ldap_enabled,
@@ -329,6 +334,7 @@ class gitlab(
   validate_re($gitlab_projects, '^\d+$', 'gitlab_projects is not valid')
   validate_re($gitlab_unicorn_port, '^\d+$', 'gitlab_unicorn_port is not valid')
   validate_re($gitlab_unicorn_worker, '^\d+$', 'gitlab_unicorn_worker is not valid')
+  validate_re($gitlab_bundler_jobs, '^\d+$', 'gitlab_bundler_jobs is not valid')
   validate_re($ensure, '(present|latest)', 'ensure is not valid (present|latest)')
   validate_re($ssh_port, '^\d+$', 'ssh_port is not a valid port')
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -69,7 +69,7 @@ class gitlab::install inherits gitlab {
   }
 
   exec { 'install gitlab':
-    command => "bundle install --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
+    command => "bundle install -j${gitlab_bundler_jobs} --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
     cwd     => "${git_home}/gitlab",
     unless  => 'bundle check',
     timeout => 0,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,7 @@ class gitlab::params {
   $gitlab_unicorn_port      = '8080'
   $gitlab_unicorn_worker    = '2'
   $gitlab_bundler_flags     = '--deployment'
+  $gitlab_bundler_jobs      = $::processorcount
   $gitlab_ensure_postfix    = true
   $exec_path                = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   $ldap_enabled             = false

--- a/spec/classes/gitlab_config_spec.rb
+++ b/spec/classes/gitlab_config_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 # Gitlab
 describe 'gitlab' do
   let(:facts) {{
-    :osfamily  => 'Debian',
-    :fqdn      => 'gitlab.fooboozoo.fr',
-    :sshrsakey => 'AAAAB3NzaC1yc2EAAAA'
+    :osfamily       => 'Debian',
+    :fqdn           => 'gitlab.fooboozoo.fr',
+    :processorcount => '2',
+    :sshrsakey      => 'AAAAB3NzaC1yc2EAAAA'
   }}
 
   ## Parameter set

--- a/spec/classes/gitlab_init_spec.rb
+++ b/spec/classes/gitlab_init_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 # Gitlab
 describe 'gitlab' do
   let(:facts) {{
-    :osfamily  => 'Debian',
-    :fqdn      => 'gitlab.fooboozoo.fr',
-    :sshrsakey => 'AAAAB3NzaC1yc2EAAAA'
+    :osfamily       => 'Debian',
+    :fqdn           => 'gitlab.fooboozoo.fr',
+    :processorcount => '2',
+    :sshrsakey      => 'AAAAB3NzaC1yc2EAAAA'
   }}
 
   describe 'input validation' do

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 # Gitlab
 describe 'gitlab' do
   let(:facts) {{
-    :osfamily  => 'Debian',
-    :fqdn      => 'gitlab.fooboozoo.fr',
-    :sshrsakey => 'AAAAB3NzaC1yc2EAAAA'
+    :osfamily       => 'Debian',
+    :fqdn           => 'gitlab.fooboozoo.fr',
+    :processorcount => '2',
+    :sshrsakey      => 'AAAAB3NzaC1yc2EAAAA'
   }}
 
   ## Parameter set
@@ -30,6 +31,7 @@ describe 'gitlab' do
       :gitlab_unicorn_port      => '8888',
       :gitlab_unicorn_worker    => '8',
       :gitlab_bundler_flags     => '--no-deployment',
+      :gitlab_bundler_jobs      => '1',
       :exec_path                => '/opt/bw/bin:/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin',
       :ldap_host                => 'ldap.fooboozoo.fr',
       :ldap_base                => 'dc=fooboozoo,dc=fr',
@@ -153,7 +155,7 @@ describe 'gitlab' do
         it { should contain_exec('install gitlab').with(
           :user    => 'git',
           :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :command => 'bundle install --without development aws test postgres --deployment',
+          :command => "bundle install -j#{Facter['processorcount'].value} --without development aws test postgres --deployment",
           :unless  => 'bundle check',
           :cwd     => '/home/git/gitlab',
           :timeout => 0,
@@ -174,7 +176,7 @@ describe 'gitlab' do
           it { should contain_exec('install gitlab').with(
             :user    => 'git',
             :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :command => 'bundle install --without development aws test mysql --deployment',
+            :command => "bundle install -j#{Facter['processorcount'].value} --without development aws test mysql --deployment",
             :unless  => 'bundle check',
             :cwd     => '/home/git/gitlab',
             :timeout => 0,
@@ -326,7 +328,7 @@ describe 'gitlab' do
         it { should contain_exec('install gitlab').with(
           :user    => params_set[:git_user],
           :path    => params_set[:exec_path],
-          :command => "bundle install --without development aws test postgres #{params_set[:gitlab_bundler_flags]}",
+          :command => "bundle install -j#{params_set[:gitlab_bundler_jobs]} --without development aws test postgres #{params_set[:gitlab_bundler_flags]}",
           :unless  => 'bundle check',
           :cwd     => "#{params_set[:git_home]}/gitlab",
           :timeout => 0,
@@ -340,7 +342,7 @@ describe 'gitlab' do
           it { should contain_exec('install gitlab').with(
             :user    => params_set[:git_user],
             :path    => params_set[:exec_path],
-            :command => "bundle install --without development aws test mysql #{params_set[:gitlab_bundler_flags]}",
+            :command => "bundle install -j#{params_set[:gitlab_bundler_jobs]} --without development aws test mysql #{params_set[:gitlab_bundler_flags]}",
             :unless  => 'bundle check',
             :cwd     => "#{params_set[:git_home]}/gitlab",
             :timeout => 0,

--- a/spec/classes/gitlab_package_spec.rb
+++ b/spec/classes/gitlab_package_spec.rb
@@ -5,6 +5,7 @@ describe 'gitlab' do
   let(:facts) {{
     :osfamily  => 'Debian',
     :fqdn      => 'gitlab.fooboozoo.fr',
+    :processorcount => '2',
     :sshrsakey => 'AAAAB3NzaC1yc2EAAAA'
   }}
 

--- a/spec/classes/gitlab_service_spec.rb
+++ b/spec/classes/gitlab_service_spec.rb
@@ -5,6 +5,7 @@ describe 'gitlab' do
   let(:facts) {{
     :osfamily  => 'Debian',
     :fqdn      => 'gitlab.fooboozoo.fr',
+    :processorcount => '2',
     :sshrsakey => 'AAAAB3NzaC1yc2EAAAA'
   }}
 

--- a/spec/classes/gitlab_setup_spec.rb
+++ b/spec/classes/gitlab_setup_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 # Gitlab
 describe 'gitlab' do
   let(:facts) {{
-    :osfamily  => 'Debian',
-    :fqdn      => 'gitlab.fooboozoo.fr',
-    :sshrsakey => 'AAAAB3NzaC1yc2EAAAA'
+    :osfamily       => 'Debian',
+    :fqdn           => 'gitlab.fooboozoo.fr',
+    :processorcount => '2',
+    :sshrsakey      => 'AAAAB3NzaC1yc2EAAAA'
   }}
 
   ## Parameter set
@@ -102,7 +103,7 @@ describe 'gitlab' do
         #= With each dbtype
         ['mysql','pgsql'].each do |dbtype|
           context "for #{dbtype} devel on #{distro}" do
-            let(:facts) {{ :osfamily => distro }}
+            let(:facts) {{ :osfamily => distro, :processorcount => '2' }}
             let(:params) {{ :gitlab_dbtype => dbtype }}
             p[distro]['db_packages'][dbtype].each do |pkg|
               it { should contain_package(pkg) }
@@ -110,7 +111,7 @@ describe 'gitlab' do
           end
         end
         context "for devel dependencies on #{distro}" do
-          let(:facts) {{ :osfamily => distro }}
+          let(:facts) {{ :osfamily => distro, :processorcount => '2' }}
           p[distro]['system_packages'].each do |pkg|
             it { should contain_package(pkg) }
           end


### PR DESCRIPTION
In PR #149, @sbadia points out that we can use multiple threads with bundle.  This PR implements this setting as a parameter called `gitlab_bundler_threads`.  This is set to a safe default of 1, but we might consider collecting the result of `nproc` on our own and using that value.
