### PR TITLE
Fix the jobs flag to not break with older bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See [gitlab example](https://github.com/sbadia/vagrant-gitlab/blob/master/exampl
 * `gitlab_unicorn_port`: Port that unicorn listens on 172.0.0.1 for HTTP traffic (default: 8080)
 * `gitlab_unicorn_worker`: Number of unicorn workers (default: 2)
 * `gitlab_bundler_flags`: Flags to be passed to bundler when installing gems (default: --deployment)
-* `gitlab_bundler_jobs`: The number of jobs to use while installing gems. Should match number of CPUs on machine (default: number of system processors)
+* `gitlab_bundler_jobs`: The number of jobs to use while installing gems. Should match number of CPUs on machine (default: 1)
 * `gitlab_ensure_postfix`: Whether or not this module should ensure the postfix
   package is installed (used to manage conflicts with other modules) (default:
 true)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,7 +164,7 @@
 #
 # [*gitlab_bundler_jobs*]
 #   Number of jobs to use while installing gems.  Should match number of
-#   procs on your system (default: number of processors on system)
+#   procs on your system (default: 1)
 #
 # [*gitlab_ensure_postfix*]
 #   Whether or not this module should ensure the postfix package is

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -68,8 +68,13 @@ class gitlab::install inherits gitlab {
     }
   }
 
+  if($gitlab_bundler_jobs == '1') {
+    $gitlab_bundler_jobs_flag = ""
+  } else {
+    $gitlab_bundler_jobs_flag = " -j${gitlab_bundler_jobs}"
+  }
   exec { 'install gitlab':
-    command => "bundle install -j${gitlab_bundler_jobs} --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
+    command => "bundle install${gitlab_bundler_jobs_flag} --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
     cwd     => "${git_home}/gitlab",
     unless  => 'bundle check',
     timeout => 0,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,7 +42,7 @@ class gitlab::params {
   $gitlab_unicorn_port      = '8080'
   $gitlab_unicorn_worker    = '2'
   $gitlab_bundler_flags     = '--deployment'
-  $gitlab_bundler_jobs      = $::processorcount
+  $gitlab_bundler_jobs      = 1
   $gitlab_ensure_postfix    = true
   $exec_path                = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   $ldap_enabled             = false

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -31,7 +31,7 @@ describe 'gitlab' do
       :gitlab_unicorn_port      => '8888',
       :gitlab_unicorn_worker    => '8',
       :gitlab_bundler_flags     => '--no-deployment',
-      :gitlab_bundler_jobs      => '1',
+      :gitlab_bundler_jobs      => '2',
       :exec_path                => '/opt/bw/bin:/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin',
       :ldap_host                => 'ldap.fooboozoo.fr',
       :ldap_base                => 'dc=fooboozoo,dc=fr',
@@ -160,7 +160,7 @@ describe 'gitlab' do
         it { should contain_exec('install gitlab').with(
           :user    => 'git',
           :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :command => "bundle install -j#{Facter['processorcount'].value} --without development aws test postgres --deployment",
+          :command => "bundle install --without development aws test postgres --deployment",
           :unless  => 'bundle check',
           :cwd     => '/home/git/gitlab',
           :timeout => 0,
@@ -181,7 +181,7 @@ describe 'gitlab' do
           it { should contain_exec('install gitlab').with(
             :user    => 'git',
             :path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :command => "bundle install -j#{Facter['processorcount'].value} --without development aws test mysql --deployment",
+            :command => "bundle install --without development aws test mysql --deployment",
             :unless  => 'bundle check',
             :cwd     => '/home/git/gitlab',
             :timeout => 0,


### PR DESCRIPTION
`Systems using bundler version 1.4 or earlier do not have the -j flag availabe
for the bundle command.  To prevent this, we need to default the -j flag to not
be present and only enable it if the user explicitly declares
gitlab_bundler_jobs.`

Implemented with your suggestion, @sbadia.  It still doesn't feel good, but if we want to support older bundler versions, I do not see another good way.  Fixes #155 
