### PR TITLE
Add flexibility in managing git user, group and home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ See [gitlab example](https://github.com/sbadia/vagrant-gitlab/blob/master/exampl
 
 * `ensure`:  Ensure gitlab/gitlab-shell repo are present, latest. absent is not yet supported (default: present)
 * `git_user`: Name of the gitlab (default: git)
+* `git_group`: Name of the group for the gitlab user (default: $git_user)
 * `git_home`: Home directory for gitlab repository (default: /home/git)
 * `git_email`: Email address for gitlab user (default: git@someserver.net)
 * `git_comment`: Gitlab user comment (default: GitLab)
+* `gitlab_manage_user`: Whether to manage the user account for gitlab (default: true)
+* `gitlab_manage_home`: Whether to manage the home directory for gitlab (default: true)
 * `gitlab_sources`: Gitlab sources (default: git://github.com/gitlabhq/gitlabhq.git)
 * `gitlab_branch`: Gitlab branch (default: 6-9-stable)
 * `gitlabshell_sources`: Gitlab-shell sources (default: git://github.com/gitlabhq/gitlab-shell.git)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@
 class gitlab::config inherits gitlab {
   File {
     owner     => $git_user,
-    group     => $git_user,
+    group     => $git_group,
   }
 
   $socket_path = "${git_home}/gitlab/tmp/sockets/gitlab.socket"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,10 @@
 #   Name of gitlab user
 #   default: git
 #
+# [*git_group*]
+#   Name of gitlab group
+#   default: $git_user
+#
 # [*git_home*]
 #   Home directory for gitlab repository
 #   default: /home/git
@@ -23,6 +27,14 @@
 # [*git_comment*]
 #   Gitlab user comment
 #   default: GitLab
+#
+# [*gitlab_manage_user*]
+#   Whether to manage the Gitlab user account
+#   default: true
+#
+# [*gitlab_manage_home*]
+#   Whether to manage the Gitlab user's home directory
+#   default: true
 #
 # [*gitlab_sources*]
 #   Gitlab sources
@@ -275,9 +287,12 @@
 class gitlab(
     $ensure                   = $gitlab::params::ensure,
     $git_user                 = $gitlab::params::git_user,
+    $git_group                = $git_user,
     $git_home                 = $gitlab::params::git_home,
     $git_email                = $gitlab::params::git_email,
     $git_comment              = $gitlab::params::git_comment,
+    $gitlab_manage_user       = $gitlab::params::gitlab_manage_user,
+    $gitlab_manage_home       = $gitlab::params::gitlab_manage_home,
     $gitlab_sources           = $gitlab::params::gitlab_sources,
     $gitlab_branch            = $gitlab::params::gitlab_branch,
     $gitlabshell_branch       = $gitlab::params::gitlabshell_branch,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,7 +17,7 @@ class gitlab::install inherits gitlab {
 
   File {
     owner => $git_user,
-    group => $git_user,
+    group => $git_group,
   }
 
   # gitlab shell
@@ -37,7 +37,7 @@ class gitlab::install inherits gitlab {
   # gitlab
   gitlab::config::database { 'gitlab':
     database => $gitlab_dbname,
-    group    => $git_user,
+    group    => $git_group,
     host     => $gitlab_dbhost,
     owner    => $git_user,
     password => $gitlab_dbpwd,
@@ -48,7 +48,7 @@ class gitlab::install inherits gitlab {
   }
 
   gitlab::config::unicorn { 'gitlab':
-    group             => $git_user,
+    group             => $git_group,
     home              => $git_home,
     http_timeout      => $gitlab_http_timeout,
     owner             => $git_user,
@@ -65,7 +65,7 @@ class gitlab::install inherits gitlab {
   }
 
   gitlab::config::resque { 'gitlab':
-    group      => $git_user,
+    group      => $git_group,
     owner      => $git_user,
     path       => "${git_home}/gitlab/config/resque.yml",
     redis_host => $gitlab_redishost,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,10 @@
 class gitlab::params {
 
   $ensure                   = 'present'
+  $gitlab_manage_user       = true
+  $gitlab_manage_home       = true
   $git_user                 = 'git'
+  $git_group                = $git_user
   $git_home                 = '/home/git'
   $git_email                = 'git@someserver.net'
   $git_comment              = 'GitLab'

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -7,17 +7,20 @@ class gitlab::setup inherits gitlab {
 
   File {
     owner     => $git_user,
-    group     => $git_user,
+    group     => $git_group,
   }
 
   # user
-  user { $git_user:
-    ensure   => present,
-    shell    => '/bin/bash',
-    password => '*',
-    home     => $git_home,
-    comment  => $git_comment,
-    system   => true,
+  if($gitlab_manage_user)
+  {
+    user { $git_user:
+      ensure   => present,
+      shell    => '/bin/bash',
+      password => '*',
+      home     => $git_home,
+      comment  => $git_comment,
+      system   => true,
+    }
   }
 
   sshkey { 'localhost':
@@ -34,9 +37,12 @@ class gitlab::setup inherits gitlab {
   }
 
   # directories
-  file { $git_home:
-    ensure => directory,
-    mode   => '0755',
+  if($gitlab_manage_home)
+  {
+    file { $git_home:
+      ensure => directory,
+      mode   => '0755',
+    }
   }
 
   file { "${git_home}/gitlab-satellites":
@@ -81,7 +87,7 @@ class gitlab::setup inherits gitlab {
   ensure_packages($system_packages)
 
   rbenv::install { $git_user:
-    group   => $git_user,
+    group   => $git_group,
     home    => $git_home,
   }
 

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -14,6 +14,7 @@ describe 'gitlab' do
   let :params_set do
     {
       :git_user                 => 'gitlab',
+      :git_group                => 'gitgroup',
       :git_home                 => '/srv/gitlab',
       :git_email                => 'gitlab@fooboozoo.fr',
       :gitlab_repodir           => '/mnt/nas',
@@ -185,7 +186,7 @@ describe 'gitlab' do
     context 'with specifics params' do
       let(:params) { params_set }
       describe 'gitlab-shell' do
-        it { should contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with(:ensure => 'file',:mode => '0644',:group => 'gitlab',:owner => 'gitlab')}
+        it { should contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with(:ensure => 'file',:mode => '0644',:group => 'gitgroup',:owner => 'gitlab')}
         it { should contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*user: #{params_set[:git_user]}$/)}
         it { should contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*gitlab_url: "http:\/\/gitlab.fooboozoo.fr#{params_set[:gitlab_relative_url_root]}"$/)}
         context 'with ssl' do
@@ -212,7 +213,7 @@ describe 'gitlab' do
       end # gitlab-shell
 
       describe 'gitlab config' do
-        it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with(:ensure => 'file',:owner => params_set[:git_user],:group => params_set[:git_user])}
+        it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with(:ensure => 'file',:owner => params_set[:git_user],:group => params_set[:git_group])}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*host: gitlab.fooboozoo.fr$/)}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*port: 80$/)}
         it { should contain_file("#{params_set[:git_home]}/gitlab/config/gitlab.yml").with_content(/^\s*https: false$/)}


### PR DESCRIPTION
These modifications allow the following:
- Externally managing the git user (for example, using an external directory service)
- Assigning a group with a different name to the git user
- Allowing the home directory to be separately managed, if desired

I've successfully deployed this on a test server.  By default, the behaviour is the same as before.
