### PR TITLE
Add gitlab_server_urls parameter to gitlab::ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,14 @@ class {
 
 ```puppet
 class { 'gitlab::ci':
-  ci_comment       => 'GitLab',
-  gitlab_domain    => $gitlab_domain,
-  gitlab_dbtype    => 'mysql',
-  gitlab_dbname    => $ci_dbname,
-  gitlab_dbuser    => $ci_dbuser,
-  gitlab_dbpwd     => $ci_dbpwd,
-  gitlab_http_port => 8081,
+  ci_comment         => 'GitLab',
+  gitlab_server_urls => ['https://gitlab.example.org']
+  gitlab_domain      => $gitlab_domain,
+  gitlab_dbtype      => 'mysql',
+  gitlab_dbname      => $ci_dbname,
+  gitlab_dbuser      => $ci_dbuser,
+  gitlab_dbpwd       => $ci_dbpwd,
+  gitlab_http_port   => 8081,
 }
 ```
 

--- a/manifests/ci.pp
+++ b/manifests/ci.pp
@@ -1,5 +1,6 @@
 #
 class gitlab::ci(
+  $gitlab_server_urls       = [],
   $ensure                   = $gitlab::ci::params::ensure,
   $ci_user                  = $gitlab::ci::params::ci_user,
   $ci_comment               = $gitlab::ci::params::ci_comment,

--- a/manifests/ci/install.pp
+++ b/manifests/ci/install.pp
@@ -52,6 +52,7 @@ class gitlab::ci::install inherits gitlab::ci {
     ensure  => file,
     content => template('gitlab/gitlab-ci-application.yml.erb'),
     mode    => '0640',
+    notify  => Service['gitlab_ci'],
   }
 
   exec { 'install gitlab-ci':

--- a/spec/classes/gitlab_ci_spec.rb
+++ b/spec/classes/gitlab_ci_spec.rb
@@ -3,10 +3,9 @@ require 'spec_helper'
 # Gitlab
 describe 'gitlab::ci' do
   let(:facts) {{
-    :osfamily       => 'Debian',
-    :fqdn           => 'gitlabci.fooboozoo.fr',
-    :processorcount => '2',
-    :sshrsakey      => 'AAAAB3NzaC1yc2EAAAA'
+    :osfamily           => 'Debian',
+    :fqdn               => 'gitlabci.fooboozoo.fr',
+    :gitlab_server_urls => ['https://gitlab.example.org']
   }}
 
   describe 'gitlab::ci internal' do

--- a/templates/gitlab-ci-application.yml.erb
+++ b/templates/gitlab-ci-application.yml.erb
@@ -1,7 +1,9 @@
 defaults: &defaults
   gitlab_server_urls:
     # Replace with your gitlab server url
-    - <%= @gitlab_domain %>
+<% Array(@gitlab_server_urls).each do |server| -%>
+    - <%= server %>
+<% end -%>
 
   ## Gitlab CI settings
   gitlab_ci:


### PR DESCRIPTION
This commit adds a gitlab_server_urls variable to specify the
gitlab servers to connct too. In addition it adds a notify to
the gitlab_ci service to restart upon configuration changes.
