### PR TITLE
Add git_group to rbenv::compile in setup

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -104,6 +104,7 @@ class gitlab::setup inherits gitlab {
 
   rbenv::compile { 'gitlab/ruby':
     user   => $git_user,
+    group  => $git_group,
     home   => $git_home,
     ruby   => $gitlab_ruby_version,
     global => true,


### PR DESCRIPTION
Stops rbenv defaulting to using the username as the group name.
