### PR TITLE
manifest/params.pp: Add ruby-devel dependency on EL platform

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,7 +79,7 @@ class gitlab::params {
       $system_packages = ['libicu-devel', 'perl-Time-HiRes','libxml2-devel',
                           'libxslt-devel','python-devel','libcurl-devel',
                           'readline-devel','openssl-devel','zlib-devel',
-                          'libyaml-devel','patch','gcc-c++']
+                          'libyaml-devel','patch','gcc-c++','ruby-devel']
     }
     default: {
       fail("${::osfamily} not supported yet")

--- a/spec/classes/gitlab_setup_spec.rb
+++ b/spec/classes/gitlab_setup_spec.rb
@@ -125,7 +125,7 @@ describe 'gitlab' do
         'system_packages' => ['libicu-devel','perl-Time-HiRes','libxml2-devel',
                               'libxslt-devel','python-devel','libcurl-devel',
                               'readline-devel','openssl-devel','zlib-devel',
-                              'libyaml-devel','patch','gcc-c++'],
+                              'libyaml-devel','patch','gcc-c++','ruby-devel'],
       }
     }
 


### PR DESCRIPTION
Currently, when install charlock_holmes gem, this is what occurs :

```
/usr/bin/gem install -v 0.6.9.4 --no-rdoc --no-ri charlock_holmes
Building native extensions.  This could take a while...
ERROR:  Error installing charlock_holmes:
        ERROR: Failed to build gem native extension.
/usr/bin/ruby extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/ruby.h
```

The package ruby-devel is missing on EL platforms.
