### PR TITLE
Add flexibility to system packages that are controller by the Gitlab mod...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,6 +260,10 @@
 #   Apply a fix for compatibility with exim as explained at github.com/gitlabhq/gitlabhq/issues/4866
 #   default: false
 #
+# [*system_packages*]
+#   Packages that Gitlab needs to work, and that will be managed by the Gitlab module
+#   default: $gitlab::params::system_packages
+#
 # === Examples
 #
 # See examples/gitlab.pp
@@ -346,6 +350,7 @@ class gitlab(
     $google_analytics_id      = $gitlab::params::google_analytics_id,
     $git_proxy                = $gitlab::params::git_proxy,
     $webserver_service_name   = $gitlab::params::webserver_service_name,
+    $system_packages          = $gitlab::params::system_packages,
     # Deprecated params
     $git_package_name         = undef,
     $company_logo_url         = $gitlab::params::company_logo_url,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -84,7 +84,7 @@ class gitlab::setup inherits gitlab {
   } # Case $::osfamily
 
   # dev. dependencies
-  ensure_packages($system_packages)
+  ensure_packages($gitlab::system_packages)
 
   rbenv::install { $git_user:
     group   => $git_group,


### PR DESCRIPTION
...ule

Currently, the list of `$system_packages` in Gitlab module, might interfer
with the setup one has already in place (ie. Duplicate declaration error).

In order to still provide a functionally working installation by default,
but yet avoid Duplicate declaration error on specific this commits allows
one to specify which `$system_packages` should be controlled by the Gitlab module.

So if one has the puppetlabs/gcc module enabled on the system, one could specify
the following `$system_packages` parameter :

```
$system_packages = ['libicu-devel', 'perl-Time-HiRes','libxml2-devel',
                    'libxslt-devel','python-devel','libcurl-devel',
                    'readline-devel','openssl-devel','zlib-devel',
                    'libyaml-devel','patch']
```

Note how gcc-c++ is not specified.

PS. I know that this module is using ensure_packages(), to check if a package is present, but another module might not, hence resulting in the error mentioned
