### PR TITLE
fixed future parser casting issues

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -359,8 +359,8 @@ class gitlab(
     $use_exim                 = $gitlab::params::use_exim,
   ) inherits gitlab::params {
   case $::osfamily {
-    Debian: {}
-    Redhat: {
+    'Debian': {}
+    'Redhat': {
       warning("${::osfamily} not fully tested with ${gitlab_branch}")
     }
     default: {


### PR DESCRIPTION
Added some double quotes to make puppet 3.7+ with parser=future happy
