### PR TITLE
Adding the port to gitlab-shell's config

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -107,7 +107,10 @@ class gitlab::install inherits gitlab {
     command => '/usr/bin/yes yes | bundle exec rake gitlab:setup RAILS_ENV=production',
     cwd     => "${git_home}/gitlab",
     creates => "${git_home}/.gitlab_setup_done",
-    require => Exec['install gitlab'],
+    require => [
+      Exec['install gitlab-shell'],
+      Exec['install gitlab'],
+    ],
     notify  => Exec['precompile assets'],
     before  => Exec['run migrations'],
   }

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -68,7 +68,7 @@ describe 'gitlab' do
       describe 'gitlab-shell' do
         it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with(:ensure => 'file', :mode => '0644', :group => 'git', :owner => 'git')}
         it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with_content(/^\s*user: git$/)}
-        it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with_content(/^\s*gitlab_url: "http:\/\/gitlab.fooboozoo.fr\/"$/)}
+        it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with_content(/^\s*gitlab_url: "http:\/\/gitlab.fooboozoo.fr:80\/"$/)}
         it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with_content(/^\s*self_signed_cert: false$/)}
         it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with_content(/^\s*repos_path: "\/home\/git\/repositories"$/)}
         it { is_expected.to contain_file('/home/git/gitlab-shell/config.yml').with_content(/^\s*auth_file: "\/home\/git\/.ssh\/authorized_keys"$/)}
@@ -162,7 +162,8 @@ describe 'gitlab' do
           :cwd     => '/home/git/gitlab',
           :creates => '/home/git/.gitlab_setup_done',
           :before  => 'Exec[run migrations]',
-          :require => 'Exec[install gitlab]',
+          :require => ['Exec[install gitlab-shell]',
+                        'Exec[install gitlab]'],
           :notify  => 'Exec[precompile assets]'
         )}
         it { is_expected.to contain_exec('precompile assets').with(
@@ -183,10 +184,10 @@ describe 'gitlab' do
       describe 'gitlab-shell' do
         it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with(:ensure => 'file',:mode => '0644',:group => 'gitgroup',:owner => 'gitlab')}
         it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*user: #{params_set[:git_user]}$/)}
-        it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*gitlab_url: "http:\/\/gitlab.fooboozoo.fr#{params_set[:gitlab_relative_url_root]}"$/)}
+        it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*gitlab_url: "http:\/\/gitlab.fooboozoo.fr:80#{params_set[:gitlab_relative_url_root]}"$/)}
         context 'with ssl' do
           let(:params) { params_set.merge(params_ssl) }
-          it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*gitlab_url: "https:\/\/gitlab.fooboozoo.fr#{params_set[:gitlab_relative_url_root]}"$/)}
+          it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*gitlab_url: "https:\/\/gitlab.fooboozoo.fr:443#{params_set[:gitlab_relative_url_root]}"$/)}
         end
         it { is_expected.to contain_file("#{params_set[:git_home]}/gitlab-shell/config.yml").with_content(/^\s*self_signed_cert: false$/)}
         context 'with self signed ssl cert' do
@@ -291,7 +292,8 @@ describe 'gitlab' do
           :command => '/usr/bin/yes yes | bundle exec rake gitlab:setup RAILS_ENV=production',
           :cwd     => "#{params_set[:git_home]}/gitlab",
           :creates => "#{params_set[:git_home]}/.gitlab_setup_done",
-          :require => 'Exec[install gitlab]'
+          :require => ['Exec[install gitlab-shell]',
+                        'Exec[install gitlab]']
         )}
         it { is_expected.to contain_file("#{params_set[:git_home]}/.gitlab_setup_done").with(
           :ensure   => 'present',

--- a/templates/gitlab-shell.config.yml.erb
+++ b/templates/gitlab-shell.config.yml.erb
@@ -2,7 +2,7 @@
 user: <%= @git_user %>
 
 # Url to gitlab instance. Used for api calls. Should end with a slash.
-gitlab_url: "<%= @gitlab_ssl ? 'https' : 'http' %>://<%= @gitlab_domain %><%= @gitlab_relative_url_root ? @gitlab_relative_url_root : '/' %>"
+gitlab_url: "<%= @gitlab_ssl ? 'https' : 'http' %>://<%= @gitlab_domain %>:<%= @gitlab_ssl ? @gitlab_ssl_port : @gitlab_http_port %><%= @gitlab_relative_url_root ? @gitlab_relative_url_root : '/' %>"
 
 http_settings:
 #  user: someone


### PR DESCRIPTION
This PR is only a squash of #169 
- bad90fd Adding another resource dependency for 'setup gitlab database'
- f54086c Adding the port to gitlab-shell's config
- f7c059b Changing tests to match the config changes
- 45c59d8 Updating more tests
- 0d36045 Fixing a syntax error

Closes: #169 
