### PR TITLE
Explicitly support rhel distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,16 @@ class { 'gitlab::ci::runner':
 
 # Limitations
 
-- TBF
+This module has been built on and tested against Puppet 2.7 and higher.
+
+The module has been tested on:
+
+* RedHat Enterprise Linux 5/6/7
+* Debian 6/7
+* CentOS 5/6/7
+* Ubuntu 12.04/14.04
+
+Testing on other platforms has been light and cannot be guaranteed. 
 
 # Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -359,10 +359,7 @@ class gitlab(
     $use_exim                 = $gitlab::params::use_exim,
   ) inherits gitlab::params {
   case $::osfamily {
-    'Debian': {}
-    'Redhat': {
-      warning("${::osfamily} not fully tested with ${gitlab_branch}")
-    }
+    'Debian','Redhat': {}
     default: {
       fail("${::osfamily} not supported yet")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -4,10 +4,26 @@
   "author": "Andrew Tomaka, Steffen Roegner, Igor Galic, Uwe Kleinmann, Matt Klich, Sebastien Badia",
   "summary": "Puppet GitLab Module",
   "license": "GPLv3",
-  "source": "https://github.com/sbadia/puppet-gitlab",
+  "source": "git://github.com/sbadia/puppet-gitlab.git",
   "project_page": "https://github.com/sbadia/puppet-gitlab/",
   "issues_url": "https://github.com/sbadia/puppet-gitlab/issues",
   "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
@@ -24,6 +40,7 @@
     }
   ],
   "description": "Module to install GitLab using puppet",
+  "tags": ["gitlab","git","vcs"],
   "dependencies": [
     {"name":"alup/rbenv","version_requirement":">= 1.2.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.1.0"},


### PR DESCRIPTION
rhel and centos distrb work fine =)
  curl -s http://pub.sebian.fr/pub/centos-65-x64.log

Let's change the readme and metadata files

Closes: #55
