### PR TITLE
Added parameter to enable Unicorn to listen on give IP address

### DIFF
--- a/manifests/ci.pp
+++ b/manifests/ci.pp
@@ -30,6 +30,7 @@ class gitlab::ci(
   $gitlab_dbport            = $gitlab::ci::params::gitlabci_dbport,
   $gitlab_domain            = $gitlab::ci::params::gitlabci_domain,
   $gitlab_domain_alias      = $gitlab::ci::params::gitlab_domain_alias,
+  $gitlab_unicorn_listen    = $gitlab::ci::params::gitlabci_unicorn_listen,
   $gitlab_unicorn_port      = $gitlab::ci::params::gitlabci_unicorn_port,
   $gitlab_unicorn_worker    = $gitlab::ci::params::gitlabci_unicorn_worker,
   $bundler_flags            = $gitlab::ci::params::gitlabci_bundler_flags,

--- a/manifests/ci/install.pp
+++ b/manifests/ci/install.pp
@@ -36,6 +36,7 @@ class gitlab::ci::install inherits gitlab::ci {
     owner             => $ci_user,
     path              => "${ci_home}/gitlab-ci/config/unicorn.rb",
     relative_url_root => $gitlab_relative_url_root,
+    unicorn_listen    => $gitlab_unicorn_listen,
     unicorn_port      => $gitlab_unicorn_port,
     unicorn_worker    => $gitlab_unicorn_worker,
   }

--- a/manifests/ci/params.pp
+++ b/manifests/ci/params.pp
@@ -32,6 +32,7 @@ class gitlab::ci::params {
   $gitlabci_ssl_self_signed   = false
   $gitlabci_projects          = '10'
   $gitlabci_username_change   = true
+  $gitlabci_unicorn_listen    = '127.0.0.1'
   $gitlabci_unicorn_port      = '8081'
   $gitlabci_unicorn_worker    = '2'
   $gitlabci_bundler_flags     = '--deployment'

--- a/manifests/config/unicorn.pp
+++ b/manifests/config/unicorn.pp
@@ -5,6 +5,7 @@ define gitlab::config::unicorn (
   $http_timeout,
   $owner,
   $path,
+  $unicorn_listen,
   $unicorn_port,
   $unicorn_worker,
   $relative_url_root = false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,6 +166,10 @@
 #   Gitlab username changing
 #   default: true
 #
+# [*gitlab_unicorn_listen*]
+#   IP address that unicorn listens on
+#   default: 127.0.0.1
+#
 # [*gitlab_unicorn_port*]
 #   Port that unicorn listens on 172.0.0.1 for HTTP traffic
 #   default: 8080
@@ -329,6 +333,7 @@ class gitlab(
     $gitlab_ssl_self_signed   = $gitlab::params::gitlab_ssl_self_signed,
     $gitlab_projects          = $gitlab::params::gitlab_projects,
     $gitlab_username_change   = $gitlab::params::gitlab_username_change,
+    $gitlab_unicorn_listen    = $gitlab::params::gitlab_unicorn_listen,
     $gitlab_unicorn_port      = $gitlab::params::gitlab_unicorn_port,
     $gitlab_unicorn_worker    = $gitlab::params::gitlab_unicorn_worker,
     $gitlab_bundler_flags     = $gitlab::params::gitlab_bundler_flags,
@@ -396,6 +401,10 @@ class gitlab(
   validate_re($gitlab_bundler_jobs, '^\d+$', 'gitlab_bundler_jobs is not valid')
   validate_re($ensure, '(present|latest)', 'ensure is not valid (present|latest)')
   validate_re($ssh_port, '^\d+$', 'ssh_port is not a valid port')
+  
+  if !is_ip_address($gitlab_unicorn_listen){
+      fail("${gitlab_unicorn_listen} is not a valid IP address")
+  }
 
   validate_string($git_user)
   validate_string($git_email)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,6 +54,7 @@ class gitlab::install inherits gitlab {
     owner             => $git_user,
     path              => "${git_home}/gitlab/config/unicorn.rb",
     relative_url_root => $gitlab_relative_url_root,
+    unicorn_listen    => $gitlab_unicorn_listen,
     unicorn_port      => $gitlab_unicorn_port,
     unicorn_worker    => $gitlab_unicorn_worker,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,7 @@ class gitlab::params {
   $gitlab_ssl_self_signed   = false
   $gitlab_projects          = '10'
   $gitlab_username_change   = true
+  $gitlab_unicorn_listen    = '127.0.0.1'
   $gitlab_unicorn_port      = '8080'
   $gitlab_unicorn_worker    = '2'
   $gitlab_bundler_flags     = '--deployment'

--- a/spec/defines/gitlab_config_unicorn_spec.rb
+++ b/spec/defines/gitlab_config_unicorn_spec.rb
@@ -12,13 +12,8 @@ describe 'gitlab::config::unicorn', :type => :define do
       :path              => '/home/git/gitlab/config/unicorn.rb',
       :relative_url_root => false,
       :unicorn_port      => 8080,
+      :unicorn_listen    => '127.0.0.1',
       :unicorn_worker    => 2
-    }
-  end
-
-  let :params_url do
-    {
-      :relative_url_root => '/blahforge'
     }
   end
 
@@ -40,9 +35,20 @@ describe 'gitlab::config::unicorn', :type => :define do
 
 
     context 'with non default url-root-path' do
-      let(:params) { params_set.merge(params_url) }
+      let(:params) { params_set.merge(:relative_url_root => '/blahforge') }
         it { is_expected.to contain_file('/home/git/gitlab/config/unicorn.rb').with_content(/^\s*ENV\['RAILS_RELATIVE_URL_ROOT'\] = "\/blahforge"$/)}
     end
+
+    context 'with non default unicorn_listen param' do
+      let(:params) { params_set.merge(:unicorn_listen => '1.3.3.7') }
+        it { is_expected.to contain_file('/home/git/gitlab/config/unicorn.rb').with_content(/^\s*listen "1.3.3.7:8080", :tcp_nopush => true$/)}
+    end
+
+    context 'with non default unicorn_port param' do
+      let(:params) { params_set.merge(:unicorn_port => '666') }
+        it { is_expected.to contain_file('/home/git/gitlab/config/unicorn.rb').with_content(/^\s*listen "127.0.0.1:666", :tcp_nopush => true$/)}
+    end
+
 
   end
 end

--- a/templates/unicorn.rb.erb
+++ b/templates/unicorn.rb.erb
@@ -44,7 +44,7 @@ working_directory "<%= @home %>/<%= @name %>"
 # listen on both a Unix domain socket and a TCP port,
 # we use a shorter backlog for quicker failover when busy
 listen "<%= @home %>/<%= @name %>/tmp/sockets/<%= @name %>.socket", :backlog => 64
-listen "127.0.0.1:<%= @unicorn_port %>", :tcp_nopush => true
+listen "<%= @unicorn_listen %>:<%= @unicorn_port %>", :tcp_nopush => true
 
 # nuke workers after 30 seconds instead of 60 seconds (the default)
 timeout <%= @http_timeout %>


### PR DESCRIPTION
Closes: #196

(cherry picked from commit 5ad666d700366ec3a5971f3bd43f047b7dbc0390)
(cherry picked + squash from commit 8061750231d2eaaf992dbc22bbe2d5fdfe3d58a8)

Spec-tests fixed by sbadia, see
https://github.com/sbadia/puppet-gitlab/pull/196#issuecomment-61342469
