### PR TITLE
check for existence of update hook

### DIFF
--- a/templates/update.erb
+++ b/templates/update.erb
@@ -8,6 +8,8 @@ refname = ARGV[0]
 key_id  = ENV['GL_ID']
 repo_path = Dir.pwd
 
-require_relative '../lib/gitlab_update'
-
-GitlabUpdate.new(repo_path, key_id, refname).exec
+update_file = '<%= @git_home %>/gitlab-shell/lib/gitlab_update.rb'
+if File.file?(update_file)
+        require update_file
+        GitlabUpdate.new(repo_path, key_id, refname).exec
+end


### PR DESCRIPTION
It seems that in the latest version of gitlab-shell they have removed the update hook:
https://gitlab.com/gitlab-org/gitlab-shell/commit/7eb45672b77a0337e6568ef64cd84e13027f2d7b

I'm using 
* gitlab_branch         => '7-4-stable',
* gitlabshell_branch    => 'v2.1.0',

I've adopted this solution because it seems to me the most compatible with different versions of gitlab and gitlab-shell.

Comments are welcome :+1: 