### PR TITLE
msync: remove 2.7 series, add puppet 4.x lint and blacksmith

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@
 ---
 language: ruby
 bundler_args: --without system_tests
-script: "bundle exec rake validate && bundle exec rake metadata && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 sudo: false
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.4"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.4"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.7"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,22 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                    :require => false
-  gem 'puppetlabs_spec_helper',  :require => false
-  gem 'rspec-puppet',            :require => false
-  gem 'puppet-syntax',           :require => false
-  gem 'puppet-lint',             :require => false
-  gem 'puppet-lint-param-docs',  :require => false
-  gem 'metadata-json-lint',      :require => false
-  gem 'puppet_facts',            :require => false
-  gem 'json',                    :require => false
+  gem 'puppetlabs_spec_helper',                :require => false
+  gem 'rspec-puppet', '2.0.1',                 :require => false
+  gem 'puppet-blacksmith',                     :require => false
+  gem 'puppet-lint-param-docs',                :require => false
+  gem 'puppet-lint-absolute_classname-check',  :require => false
+  gem 'puppet-lint-absolute_template_path',    :require => false
+  gem 'puppet-lint-trailing_newline-check',    :require => false
+  gem 'puppet-lint-unquoted_string-check',     :require => false
+  gem 'puppet-lint-leading_zero-check',        :require => false
+  gem 'puppet-lint-variable_contains_upcase',  :require => false
+  gem 'puppet-lint-numericvariable',           :require => false
+  gem 'puppet-lint-file_ensure-check',         :require => false
+  gem 'puppet-lint-trailing_comma-check',      :require => false
+  gem 'metadata-json-lint',                    :require => false
+  gem 'puppet_facts',                          :require => false
+  gem 'json',                                  :require => false
 end
 
 group :system_tests do

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@
 # Configs https://github.com/sbadia/modulesync_configs/
 #
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 
@@ -26,8 +27,4 @@ namespace :module do
   task :build do
     exec "rsync -rv --exclude-from=#{TDIR}/.forgeignore . /tmp/#{NAME};cd /tmp/#{NAME};puppet module build"
   end
-end
-
-task :metadata do
-  sh "metadata-json-lint metadata.json"
 end


### PR DESCRIPTION
Update puppet versions (remove 2.7.x series), add blacksmith, and puppet4 lint checks