### PR TITLE
Offer a coherent gitlab_dbport default value

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class gitlab::params {
   $gitlab_dbuser            = 'gitlab_user'
   $gitlab_dbpwd             = 'changeme'
   $gitlab_dbhost            = 'localhost'
-  $gitlab_dbport            = '5432'
+  $gitlab_dbport            = '3306'
   $gitlab_domain            = $::fqdn
   $gitlab_domain_alias      = false
   $gitlab_repodir           = $git_home


### PR DESCRIPTION
In the params.pp the $gitlab_dbtype param is set to mysql, but the
default values for $gitlab_dbport is set to '5432' (PostgreSQL default
port) when it should be '3306' (MySQL default port)