### PR TITLE
Missing System Package: 'cmake', 'pkg-config', 'libkrb5-dev', 'ruby-execjs'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,7 +98,8 @@ class gitlab::params {
     'Debian': {
       # system packages
       $system_packages = ['libicu-dev', 'python2.7','python-docutils',
-                          'libxml2-dev', 'libxslt1-dev','python-dev']
+                          'libxml2-dev', 'libxslt1-dev','python-dev',
+                          'cmake', 'pkg-config', 'libkrb5-dev', 'ruby-execjs']
     }
     'RedHat': {
       # system packages

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -96,7 +96,7 @@ class gitlab::setup inherits gitlab {
       group => $git_group,
       home  => $git_home,
     }
-  
+
     # By default, puppet-rbenv sets ~/.profile to load rbenv, which is
     # read when bash is invoked as an interactive login shell, but we
     # also need ~/.bashrc to load rbenv (which is read by interactive
@@ -107,7 +107,7 @@ class gitlab::setup inherits gitlab {
       target  => "${git_home}/.profile",
       require => Rbenv::Install[$git_user],
     }
-  
+
     rbenv::compile { 'gitlab/ruby':
       user   => $git_user,
       group  => $git_group,
@@ -119,7 +119,7 @@ class gitlab::setup inherits gitlab {
         Exec['install gitlab'],
       ],
     }
-  
+
     #Gitlab <= 6.3 requires us to install the charlock_holmes gem
     rbenv::gem { 'charlock_holmes':
       ensure => '0.6.9.4',


### PR DESCRIPTION
When using Ruby-Version 2.1.5, gitlab version: 7.9-stable and gitshell v2.6.0.
puppet-gitlab lacks this system packages (refs #211)