### PR TITLE
gitlab OAuth2

### DIFF
--- a/manifests/ci.pp
+++ b/manifests/ci.pp
@@ -24,6 +24,10 @@
 #   Email address for gitlab CI user
 #   default: gilab-ci@localhost
 #
+# [*ci_support_email*]
+#   Email address of your support contact
+#   default: support@localhost
+#
 # [*ci_comment*]
 #   Gitlab CI user comment
 #   default: GitLab CI
@@ -162,6 +166,7 @@ class gitlab::ci(
   $ci_user                  = $gitlab::ci::params::ci_user,
   $ci_comment               = $gitlab::ci::params::ci_comment,
   $ci_email                 = $gitlab::ci::params::ci_email,
+  $ci_support_email         = $gitlab::ci::params::ci_support_email,
   $ci_home                  = $gitlab::ci::params::ci_home,
   $gitlabci_sources         = $gitlab::ci::params::gitlabci_sources,
   $gitlabci_branch          = $gitlab::ci::params::gitlabci_branch,

--- a/manifests/ci.pp
+++ b/manifests/ci.pp
@@ -146,6 +146,16 @@
 #   Number of jobs to use while installing gems.  Should match number of
 #   procs on your system (default: 1)
 #
+# [*omniauth_url*]
+#  The url to be used for the omniauth authentication. If the url 
+#  is not defined, the omniauth section will be skipped. (default: undef)
+#
+# [*omniauth_app_id*]
+#   The app id to use for the omniauth authentication (default: undef)
+#
+# [*omniauth_secret_id*]
+#   The app secret to use for the omniauth authentication (default: undef)
+#
 class gitlab::ci(
   $gitlab_server_urls       = [],
   $ensure                   = $gitlab::ci::params::ensure,
@@ -182,6 +192,9 @@ class gitlab::ci(
   $gitlab_unicorn_worker    = $gitlab::ci::params::gitlabci_unicorn_worker,
   $bundler_flags            = $gitlab::ci::params::gitlabci_bundler_flags,
   $bundler_jobs             = $gitlab::ci::params::gitlabci_bundler_jobs,
+  $omniauth_url = undef,
+  $omniauth_app_id = undef,
+  $omniauth_secret_id = undef,
 ) inherits gitlab::ci::params {
 
   anchor { 'gitlab::ci::begin': } ->

--- a/manifests/ci.pp
+++ b/manifests/ci.pp
@@ -197,9 +197,9 @@ class gitlab::ci(
   $gitlab_unicorn_worker    = $gitlab::ci::params::gitlabci_unicorn_worker,
   $bundler_flags            = $gitlab::ci::params::gitlabci_bundler_flags,
   $bundler_jobs             = $gitlab::ci::params::gitlabci_bundler_jobs,
-  $omniauth_url = undef,
-  $omniauth_app_id = undef,
-  $omniauth_secret_id = undef,
+  $omniauth_url             = undef,
+  $omniauth_app_id          = undef,
+  $omniauth_secret_id       = undef,
 ) inherits gitlab::ci::params {
 
   anchor { 'gitlab::ci::begin': } ->

--- a/manifests/ci/params.pp
+++ b/manifests/ci/params.pp
@@ -8,6 +8,7 @@ class gitlab::ci::params {
   $ci_home                    = '/home/gitlab_ci'
   $ci_comment                 = 'GitLab CI'
   $ci_email                   = 'gitlab-ci@localhost'
+  $ci_support_email           = 'support@localhost'
   $gitlabci_sources           = 'git://github.com/gitlabhq/gitlab-ci.git'
   $gitlabci_branch            = '5-0-stable'
   $gitlabci_manage_nginx      = true

--- a/templates/gitlab-ci-application.yml.erb
+++ b/templates/gitlab-ci-application.yml.erb
@@ -36,7 +36,7 @@ defaults: &defaults
     url: <%= @omniauth_url %>
     app_id: <%= @omniauth_app_id %>
     app_secret: <%= @omniauth_secret_id %>
-  <%- endif %>
+  <% end -%>
 
 
 development:

--- a/templates/gitlab-ci-application.yml.erb
+++ b/templates/gitlab-ci-application.yml.erb
@@ -31,6 +31,17 @@ defaults: &defaults
     enabled: true
     plain_url: "http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
     ssl_url:   "https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
+  <%- if @omniauth_url %>
+    gitlab_server:
+      url: <%= @omniauth_url %>
+      app_id: <%= @omniauth_app_id %>
+      app_secret: <%= @omniauth_secret_id %>
+  <%- endif %>
+  omniauth:
+    enabled: true
+    plain_url: "http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
+    ssl_url:   "https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
+  <%- if @gitlab %>
 
 
 development:

--- a/templates/gitlab-ci-application.yml.erb
+++ b/templates/gitlab-ci-application.yml.erb
@@ -17,7 +17,7 @@ defaults: &defaults
     email_from: <%= @ci_email %>
 
     # Email address of your support contact (default: same as email_from)
-    support_email: support@localhost
+    support_email: <%= @ci_support_email %>
 
     # Default project notifications settings: 
     #

--- a/templates/gitlab-ci-application.yml.erb
+++ b/templates/gitlab-ci-application.yml.erb
@@ -32,16 +32,11 @@ defaults: &defaults
     plain_url: "http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
     ssl_url:   "https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
   <%- if @omniauth_url %>
-    gitlab_server:
-      url: <%= @omniauth_url %>
-      app_id: <%= @omniauth_app_id %>
-      app_secret: <%= @omniauth_secret_id %>
+  gitlab_server:
+    url: <%= @omniauth_url %>
+    app_id: <%= @omniauth_app_id %>
+    app_secret: <%= @omniauth_secret_id %>
   <%- endif %>
-  omniauth:
-    enabled: true
-    plain_url: "http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
-    ssl_url:   "https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
-  <%- if @gitlab %>
 
 
 development:


### PR DESCRIPTION
gitlab-ci without support for oauth is useless if you use any of the omniauth authentication in gitlab. 
So I added the support for the newly supported oauth2 in gitlab-ci.
I also added the support for the support_email.