### PR TITLE
Install fix

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -96,17 +96,7 @@ class gitlab::setup inherits gitlab {
     rbenv::install { $git_user:
       group => $git_group,
       home  => $git_home,
-    }
-
-    # By default, puppet-rbenv sets ~/.profile to load rbenv, which is
-    # read when bash is invoked as an interactive login shell, but we
-    # also need ~/.bashrc to load rbenv (which is read by interactive
-    # but non-login shells). This works, but may not be the best
-    # solution, please see issue #114 if you have a better solution.
-    file { "${git_home}/.bashrc":
-      ensure  => link,
-      target  => "${git_home}/.profile",
-      require => Rbenv::Install[$git_user],
+      rc    => '.bashrc',
     }
 
     rbenv::compile { 'gitlab/ruby':

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -96,7 +96,7 @@ class gitlab::setup inherits gitlab {
     rbenv::install { $git_user:
       group => $git_group,
       home  => $git_home,
-      rc    => '.bashrc',
+      rc    => ['.bashrc','.profile'],
     }
 
     rbenv::compile { 'gitlab/ruby':


### PR DESCRIPTION
Proposing a better fix to the install rc file creation from #114, this is dependent on an upstream fix from rbenv (https://github.com/alup/puppet-rbenv/pull/121) that adds support for multiple RC files.  

Commit c816c60 includes a change to specify the rcfile in the install block, this works without upstream fix.

Commit d9adfbc includes a change that requires the upstream rbenv fix.

Without this fix I ran into an error on the first puppet run that it couldn't find bundler, this might have been a dependency issue but with this fix it works on the first puppet run.
