### PR TITLE
Fix permissions for `public/uploads` directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -53,10 +53,15 @@ class gitlab::config inherits gitlab {
       "${git_home}/gitlab/tmp/pids",
       "${git_home}/gitlab/tmp/sockets",
       "${git_home}/gitlab/public",
-      "${git_home}/gitlab/public/uploads",
     ]:
     ensure => directory,
     mode   => '0755',
+  }
+  file { [
+      "${git_home}/gitlab/public/uploads",
+    ]:
+    ensure => directory,
+    mode   => '0750',
   }
 
   #gitlab does not provide an option to configure a log directory, so create a symlink to

--- a/spec/classes/gitlab_config_spec.rb
+++ b/spec/classes/gitlab_config_spec.rb
@@ -83,10 +83,17 @@ describe 'gitlab' do
         )}
       end # gitlab logrotate
       describe 'gitlab directories' do
-        ['gitlab/tmp','gitlab/tmp/pids','gitlab/tmp/sockets','gitlab/log','gitlab/public','gitlab/public/uploads'].each do |dir|
+        ['gitlab/tmp','gitlab/tmp/pids','gitlab/tmp/sockets','gitlab/log','gitlab/public'].each do |dir|
           it { is_expected.to contain_file("/home/git/#{dir}").with(
             :ensure => 'directory',
             :mode   => '0755'
+          )}
+        end
+
+        ['gitlab/public/uploads'].each do |dir|
+          it { is_expected.to contain_file("/home/git/#{dir}").with(
+            :ensure => 'directory',
+            :mode   => '0750'
           )}
         end
       end # gitlab directories


### PR DESCRIPTION
The permissions for the `/home/git/gitlab/public/uploads` directory are currently set incorrectly to `0755` instead of `0750`. This causes the following error when running `bundle exec rake gitlab:check RAILS_ENV=production`:

```
Uploads directory setup correctly? ... no
  Try fixing it:
  sudo chmod 0750 /home/git/gitlab/public/uploads
  For more information see:
  doc/install/installation.md in section "GitLab"
  Please fix the error above and rerun the checks.
```
