### PR TITLE
Add in the HOME environment during Exec['install gitlab']

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -91,17 +91,18 @@ class gitlab::install inherits gitlab {
     $gitlab_bundler_jobs_flag = " -j${gitlab_bundler_jobs}"
   }
   exec { 'install gitlab':
-    command => "bundle install${gitlab_bundler_jobs_flag} --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
-    cwd     => "${git_home}/gitlab",
-    unless  => 'bundle check',
-    timeout => 0,
-    require => [
+    command     => "bundle install${gitlab_bundler_jobs_flag} --without development aws test ${gitlab_without_gems} ${gitlab_bundler_flags}",
+    cwd         => "${git_home}/gitlab",
+    unless      => 'bundle check',
+    environment => "HOME=${git_home}",
+    timeout     => 0,
+    require     => [
       Gitlab::Config::Database['gitlab'],
       Gitlab::Config::Unicorn['gitlab'],
       File["${git_home}/gitlab/config/gitlab.yml"],
       Gitlab::Config::Resque['gitlab'],
     ],
-    notify  => Exec['run migrations'],
+    notify      => Exec['run migrations'],
   }
 
   exec { 'setup gitlab database':

--- a/spec/classes/gitlab_install_spec.rb
+++ b/spec/classes/gitlab_install_spec.rb
@@ -119,17 +119,18 @@ describe 'gitlab' do
       end # rack_attack config
       describe 'install gitlab' do
         it { is_expected.to contain_exec('install gitlab').with(
-          :user    => 'git',
-          :path     => '/home/git/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :command => "bundle install --without development aws test postgres --deployment",
-          :unless  => 'bundle check',
-          :cwd     => '/home/git/gitlab',
-          :timeout => 0,
-          :require => ['Gitlab::Config::Database[gitlab]',
+          :user        => 'git',
+          :path        => '/home/git/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :command     => "bundle install --without development aws test postgres --deployment",
+          :unless      => 'bundle check',
+          :cwd         => '/home/git/gitlab',
+          :environment => 'HOME=/home/git',
+          :timeout     => 0,
+          :require     => ['Gitlab::Config::Database[gitlab]',
                         'Gitlab::Config::Unicorn[gitlab]',
                         'File[/home/git/gitlab/config/gitlab.yml]',
                         'Gitlab::Config::Resque[gitlab]'],
-          :notify  => 'Exec[run migrations]'
+          :notify      => 'Exec[run migrations]'
         )}
         it { is_expected.to contain_exec('run migrations').with(
           :command     => 'bundle exec rake db:migrate RAILS_ENV=production',
@@ -140,13 +141,14 @@ describe 'gitlab' do
         context 'postgresql' do
           let(:params) {{ :gitlab_dbtype => 'pgsql' }}
           it { is_expected.to contain_exec('install gitlab').with(
-            :user    => 'git',
-            :path     => '/home/git/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :command => "bundle install --without development aws test mysql --deployment",
-            :unless  => 'bundle check',
-            :cwd     => '/home/git/gitlab',
-            :timeout => 0,
-            :require => ['Gitlab::Config::Database[gitlab]',
+            :user        => 'git',
+            :path        => '/home/git/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :command     => "bundle install --without development aws test mysql --deployment",
+            :unless      => 'bundle check',
+            :cwd         => '/home/git/gitlab',
+            :environment => 'HOME=/home/git',
+            :timeout     => 0,
+            :require     => ['Gitlab::Config::Database[gitlab]',
                         'Gitlab::Config::Unicorn[gitlab]',
                         'File[/home/git/gitlab/config/gitlab.yml]',
                         'Gitlab::Config::Resque[gitlab]']


### PR DESCRIPTION
This will stop the git user from trying to `bundle install` to `/.bundle`, which it will never have permissions to.

~~Unsure why I had to add the `-j1` flag to the command spec as well, but it was failing on my machine on the master branch already with the same error.~~ Travis failed with that, so I can only assume it was weirdness on my machine.

Edit: To flesh this out some more, I was seeing the following error:

```
Notice: /Stage[main]/Gitlab::Install/Exec[install gitlab]/returns: There was an error while trying to write to
Notice: /Stage[main]/Gitlab::Install/Exec[install gitlab]/returns: `/.bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47`.
Notice: /Stage[main]/Gitlab::Install/Exec[install gitlab]/returns: It is likely that you need to grant write permissions for that path.
```
